### PR TITLE
Allow anything for the assertion label.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [1.1.0]
 ### Added
- - Unit Tests for Hamcrest itself
- - UtInstanceOfMatcher
+ - Unit Tests for Hamcrest itself (#2)
+ - `UtInstanceOfMatcher` (#1)
 
 ### Changed
- - Must use factory functions for reporters rather than New Object (#3).
+ - Must use factory functions for reporters rather than `New Object` (#3).
+ - Test labels can now be anything (not just strings, #6)
 
 ### Fixed
-
+ - Log failures within `ut test` now affect return code (#6)
 
 ## [1.0.1] - Inital version available on GitHub
 ### Changed

--- a/Source/Core/Core.jsl
+++ b/Source/Core/Core.jsl
@@ -56,7 +56,7 @@ ut assert that = Function( {test expr, matcher, label = ""},
 	// call to ut assert that.
 
 	If( !Is Expr( Name Expr( test expr ) ),
-		ut global reporter:add expression failure( label );
+		ut global reporter:add expression failure( Name Expr(label) );
 		Return( 0 );
 	);
 	
@@ -77,7 +77,7 @@ ut assert that = Function( {test expr, matcher, label = ""},
 	If( !match info:success,
 		If( did throw == 0,
 			ut global reporter:add failure(
-				label,
+				Name Expr(label),
 				Name Expr( test expr ),
 				matcher:describe(),
 				match info:mismatch,
@@ -86,7 +86,7 @@ ut assert that = Function( {test expr, matcher, label = ""},
 			0;
 		,
 			ut global reporter:add unexpected throw(
-				label,
+				Name Expr(label),
 				Name Expr( test expr ),
 				matcher:describe(),
 				did throw
@@ -94,7 +94,7 @@ ut assert that = Function( {test expr, matcher, label = ""},
 			0;
 		)
 	,
-		ut global reporter:add success( label, Name Expr( test expr ), matcher:describe() );
+		ut global reporter:add success( Name Expr(label), Name Expr( test expr ), matcher:describe() );
 		1;
 	);
 	

--- a/Source/Core/TestCase.jsl
+++ b/Source/Core/TestCase.jsl
@@ -1,4 +1,4 @@
-// Copyright © 2019, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
+﻿// Copyright © 2019, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 Names Default To Here( 0 );
@@ -466,10 +466,15 @@ ut test = Function({test case, test name, test expr, log benchmark = ut log benc
 				ut global reporter = ut test filtering reporter;
 				
 				log contents = _utTestNS:log;
-				::ut assert that(
-					Expr( log contents ), 
-					_utTestNS:log benchmark << Get Matcher(),
-					ut test log benchmark label(_utTestNS:test case:name, _utTestNS:test name)
+				// Qualified so that the ut test log benchmark label
+				// is used without modification
+				_utTestNS:n asserts++;
+				Insert Into(_utTestNS:results,
+					::ut assert that(
+						Expr( log contents ), 
+						_utTestNS:log benchmark << Get Matcher(),
+						ut test log benchmark label(_utTestNS:test case:name, _utTestNS:test name)
+					);
 				);
 				
 				ut global reporter = ut test filtering reporter << release();

--- a/Source/Core/Utils.jsl
+++ b/Source/Core/Utils.jsl
@@ -365,8 +365,8 @@ ut concat test label sep = "⮚";
 ut concat test label = Function({test case name, test name, label="", n asserts=.},
 	{labelList},
 	labelList = {};
-	If( test case name != "", Insert Into( labelList, test case name ) );
-	If( test name != "",Insert Into( labelList, test name ) );
+	Insert Into( labelList, test case name );
+	Insert Into( labelList, test name );
 	If( label != "",  Insert Into( labelList, label ) );
 	If( !Is Missing( n asserts ), Insert Into( labelList, Char( n asserts ) ) );
 	

--- a/Tests/UnitTests/AssertThatTest.jsl
+++ b/Tests/UnitTests/AssertThatTest.jsl
@@ -43,3 +43,10 @@ assert rc = with noop reporter( Expr(
 	ut assert that( Expr( 2 + 2 ), 4, "hello" );
 ));
 ut assert that( Expr( assert rc ), 1, "accepts optional label");
+
+// Label can be anything
+assert rc = with noop reporter( Expr(
+	ut assert that( Expr( 2 + 2 ), 4, Expr(a name) );
+));
+ut assert that( Expr( assert rc ), 1, "label can be anything");
+

--- a/Tests/UnitTests/TestCaseLogBenchmarkTest.jsl
+++ b/Tests/UnitTests/TestCaseLogBenchmarkTest.jsl
@@ -1,0 +1,89 @@
+﻿// Copyright © 2019, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+Log Benchmark = ut test case("Log Benchmark")
+	<<Setup(Expr(
+		reporter = ut mock reporter();
+	))
+	<<Teardown(Expr(
+		reporter << Verify Expectations;
+	));
+
+ut test(Log Benchmark, "Log Bench Default Does Not Capture Log", Expr(
+	old default = ut log bench default;
+	ut log bench default = -1; // default default
+	log = Log Capture(rc = ut with reporter(reporter, Expr(
+		ut test("case", "name", Expr(Print("stuff")));
+	)));
+	ut log bench default = old default;
+	ut assert that(Expr(rc), 1);
+	ut assert that(Expr(log), ut ignoring whitespace("\["stuff"]\"));
+));
+
+ut test(Log Benchmark, "Log Bench Off Captures and Ignores Logging", Expr(
+	log = Log Capture(rc = ut with reporter(reporter, Expr(
+		ut test("case", "name", Expr(Print("stuff")), ut log bench(0));
+	)));
+	ut assert that(Expr(rc), 1);
+	ut assert that(Expr(log), "");
+));
+
+ut test(Log Benchmark, "Log Bench On Captures And Asserts Empty Log", Expr(
+	reporter << Expect Call(Expr(add failure(ut wild, ut wild, ut wild, ut wild, ut wild, ut wild)));
+	log = Log Capture(rc = ut with reporter(reporter, Expr(
+		ut test("case", "name", Expr(Print("stuff")), ut log bench(1));
+	)));
+	ut assert that(Expr(rc), 0);
+	ut assert that(Expr(log), "");
+));
+
+ut test(Log Benchmark, "Log Bench Default Can Be Changed", Expr(
+	old default = ut log bench default;
+	ut log bench default = 0;
+	log = Log Capture(rc = ut with reporter(reporter, Expr(
+		ut test("case", "name", Expr(Print("stuff")) /*no log bench specified*/);
+	)));
+	ut log bench default = old default;
+	ut assert that(Expr(rc), 1);
+	ut assert that(Expr(log), "");
+));
+
+ut test(Log Benchmark, "Log Bench On Does Not Report Successes", Expr(
+	rc = ut with reporter(reporter, Expr(
+		ut test("case", "name", Expr(Write("stuff")), ut log bench(1, "stuff"));
+	));
+	ut assert that(Expr(rc), 1);
+));
+
+ut test(Log Benchmark, "Log Bench On Can Assert On Exact Log", Expr(
+	reporter << Expect Call(Expr(add failure(ut wild, ut wild, ut wild, ut wild, ut wild, ut wild)));
+	rc = ut with reporter(reporter, Expr(
+		ut test("case", "name", Expr(Write("stuff")), ut log bench(1, "other stuff"));
+	));
+	ut assert that(Expr(rc), 0);
+));
+
+ut test(Log Benchmark, "Log Bench On Can Use a Matcher And Succeed", Expr(
+	rc = ut with reporter(reporter, Expr(
+		ut test("case", "name", Expr(Write("stuff")), ut log bench(1, ut contains("tuf")));
+	));
+	ut assert that(Expr(rc), 1);
+));
+
+ut test(Log Benchmark, "Log Bench On Can Use a Matcher And Fail", Expr(
+	reporter << Expect Call(Expr(add failure(ut wild, ut wild, ut wild, ut wild, ut wild, ut wild)));
+	rc = ut with reporter(reporter, Expr(
+		ut test("case", "name", Expr(Write("stuff")), ut log bench(1, ut ignoring whitespace("stu")));
+	));
+	ut assert that(Expr(rc), 0);
+));
+
+ut test(Log Benchmark, "Log Bench On Can Use a Matcher And Fail", Expr(
+	old label gen = Name Expr(ut test log benchmark label);
+	ut test log benchmark label = Function({c, n}, "my " || c || " " || n);
+	reporter << Expect Call(Expr(add failure("my case name", ut wild, ut wild, ut wild, ut wild, ut wild)));
+	rc = ut with reporter(reporter, Expr(
+		ut test("case", "name", Expr(Write("stuff")), ut log bench(1));
+	));
+	ut test log benchmark label = Name Expr(old label gen);
+));

--- a/Tests/UnitTests/TestCaseTest.jsl
+++ b/Tests/UnitTests/TestCaseTest.jsl
@@ -1,0 +1,34 @@
+// Copyright © 2019, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// TODO: 
+// - use ut test case(): setup/teardown
+// - multiple assertions (worst is returned)
+// - labels send to reporter correctly (empty labels)
+
+// SUCCESS
+test case rc = with noop reporter( Expr(
+	ut test( "TestCase", "Success", Expr(
+		ut assert that( Expr( 0 + 1 ), 1 );
+	));
+));
+ut assert that( Expr( test case rc ), 1 );
+
+// FAILURE
+test case rc = with noop reporter( Expr(
+	ut test( "TestCase", "Failure", Expr(
+		ut assert that( Expr( 0 + 1 ), 0 );
+	));
+));
+ut assert that( Expr( test case rc ), 0 );
+
+// LOG FAILURE
+test case rc = with noop reporter( Expr(
+	ut test( "TestCase", "Failure", 
+		Expr(
+			Print( "Hello, world." );
+		), 
+		ut log bench( 1 )
+	);
+));
+ut assert that( Expr( test case rc ), 0 );


### PR DESCRIPTION
Also, ut test should return code should match
information given to the reporter.

Closes #6 