### PR TITLE
General MessageMatcher improvements. Add enabled matcher.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this project will be documented in this file.
  - Unit Tests for Addin Reporters (basic, #23)
  - `Matchers/Custom` and `Reporters/Custom` folders for installation of user-defined classes (#24)
  - Allow user-defined assertions to be used with `ut test` (#27)
+ - `UtTypedMatcher` now supports `Scriptable` as an allowable type (#42)
+ - Added `ut enabled` matcher (#40 #42)
 
 ### Changed
  - Must use factory functions for reporters rather than `New Object` (#3).
@@ -18,6 +20,9 @@ All notable changes to this project will be documented in this file.
  - Reworded `ut all of` mismatch to be less confusing (#21)
  - `StreamingLogReporter` now gives a better error message when expecting an expression (#22)
  - `ut global reporter` will no longer be overwritten if `Core.jsl` is included multiple times (#26)
+ - `UtMessageMatcher` mismatch message has been improved (#42)
+ - `UtMessageMatcher` will now always send a message if the object is scriptable instead of attempting to
+    detect messages that are allowed. If a message is not supported by an object, it will return missing. (#42)
 
 ### Fixed
  - Log failures within `ut test` now affect return code (#6)

--- a/Source/Core/Matchers/Typed.jsl
+++ b/Source/Core/Matchers/Typed.jsl
@@ -1,4 +1,4 @@
-// Copyright © 2019, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
+﻿// Copyright © 2019, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 Names Default to Here( 0 );
@@ -36,11 +36,16 @@ Define Class(
 	//    method, which should be defined by the subclass.
 	matches = Method( {test expr},
 		actual = test expr;
-		If( Contains( self:allowable types, As Name( Type( Name Expr( actual ) ) ) ),
-			self << typed matches( Name Expr( actual ) );
+		If( 
+			Contains( self:allowable types, As Name( Type( Name Expr( actual ) ) ) ),
+				self << typed matches( Name Expr( actual ) );
 		,
-			mismatch = Eval Insert( "was ^ut get show string( Name Expr( actual ) )^ and type mismatch (Actual=^Type( Name Expr( actual ) )^, Expected=^this:format allowable types()^)" ); 
-			ut match info failure( mismatch );
+			Contains( self:allowable types, Expr( Scriptable ) ) & Is Scriptable( Name Expr( actual ) ),
+				self << typed matches( Name Expr( actual ) );
+		,
+			//else
+				mismatch = Eval Insert( "was ^ut get show string( Name Expr( actual ) )^ and type mismatch (Actual=^Type( Name Expr( actual ) )^, Expected=^this:format allowable types()^)" ); 
+				ut match info failure( mismatch );
 		)
 	);
 	

--- a/Source/Matchers/Messages.jsl
+++ b/Source/Matchers/Messages.jsl
@@ -1,4 +1,4 @@
-// Copyright © 2019, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
+﻿// Copyright © 2019, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 Names Default To Here( 0 );
@@ -13,22 +13,22 @@ Names Default To Here( 0 );
 		to the resulting object.
 */
 Define Class("UtMessageMatcher", 
-	Base Class( UtMatcher ),
+	Base Class( "UtTypedMatcher" ),
 	inner = Empty();
 	description = "";
 	message = "";
+	allowable types = {Scriptable};
 	_init_ = Method( {inner, description, message},
 		this:inner = inner;
 		this:description = description;
 		this:message = message;
 	);
-	matches = Method( {test expr},
-		actual obj = test expr;
-		if( ut object supports message( Name Expr( actual obj ), this:message ),
-			Eval( Eval Expr( this:inner << Matches( Send( actual obj, Expr( this:message ) ) ) ) );
-		,
-			ut match info failure( ut detailed type( Name Expr( actual obj ) ) || " does not support <<" || this:message )
+	typed matches = Method( {actual},
+		match info = Eval( Eval Expr( this:inner << Matches( Send( actual, Expr( this:message ) ) ) ) );
+		If( !match info:success,
+			match info:mismatch = Eval Insert( "^ut detailed type( actual )^ << ^this:message^ ^match info:mismatch^" );
 		);
+		match info;
 	);
 	describe = Method( {},
 		this:description || " " || inner:describe();
@@ -36,6 +36,25 @@ Define Class("UtMessageMatcher",
 );
 
 // Section: Globals
+
+/*	Function: ut message
+		---Prototype---
+		ut message( UtMatcher matcher, description, message );
+		---------------
+		General message matcher factory. Mostly used in other factory functions,
+		but can be used in tests if needed.
+		
+		Factory function for <UtMessageMatcher>.
+
+	Arguments:
+		matcher - any object
+*/
+ut matcher factory( "ut message" );
+ut message = Function( {matcher, description, message},
+	{obj},
+	obj = New Object( UtMessageMatcher( ut ensure matcher( Name Expr( matcher ) ), description, message ) );
+	obj:self = obj;
+);
 
 /* 
 	Function: ut title
@@ -57,7 +76,7 @@ Define Class("UtMessageMatcher",
 */
 ut matcher factory( "ut title" );
 ut title = Function( {matcher},
-	New Object( UtMessageMatcher( ut ensure matcher( Name Expr( matcher ) ), "title", "Get Title" ) );
+	ut message( Name Expr( matcher ), "title", "Get Title" );
 );
 
 /* 
@@ -80,7 +99,33 @@ ut title = Function( {matcher},
 */
 ut matcher factory( "ut text" );
 ut text = Function( {matcher},
-	New Object( UtMessageMatcher( ut ensure matcher( Name Expr( matcher ) ), "text", "Get Text" ) );
+	ut message( Name Expr( matcher ), "text", "Get Text" );
+);
+
+/* 	Function: ut enabled
+		---Prototype---
+		ut enabled( UtMatcher matcher )
+		---------------
+		Compare inner matcher to the result of sending the Get Enabled message to the result.
+		
+		NOTE: This message checks the enabled state set by the Enabled message and not the Enable message.
+		
+		Factory function for <UtMessageMatcher>.
+
+	Arguments:
+		matcher - any object
+
+	Examples:
+		---JSL---
+		tb = Text Box( "hello, world" );
+		ut assert that( Expr( tb ), ut enabled( 1 ) );
+		tb << Enabled( 0 );
+		ut assert that( Expr( tb ), ut enabled( 0 ) );
+		---------
+*/
+ut matcher factory( "ut enabled" );
+ut enabled = Function( {matcher},
+	ut message( Name Expr( matcher ), "enabled", "Get Enabled" );
 );
 
 /* 
@@ -103,7 +148,7 @@ ut text = Function( {matcher},
 */
 ut matcher factory( "ut class name" );
 ut class name = Function( {matcher},
-	New Object( UtMessageMatcher( ut ensure matcher( Name Expr( matcher ) ), "class name", "Class Name" ) );
+	ut message( Name Expr( matcher ), "class name", "Class Name" );
 );
 
 /* 
@@ -131,5 +176,5 @@ ut class name = Function( {matcher},
 */
 ut matcher factory( "ut name" );
 ut name = Function( {matcher},
-	New Object( UtMessageMatcher( ut ensure matcher( Name Expr( matcher ) ), "name", "Get Name" ) );
+	ut message( Name Expr( matcher ), "name", "Get Name" );
 );

--- a/Tests/UnitTests/Matchers/MessagesTest.jsl
+++ b/Tests/UnitTests/Matchers/MessagesTest.jsl
@@ -1,0 +1,156 @@
+﻿// Copyright © 2019, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// ------------------------------------ ut title ------------------------------------
+ut test( "TitleMatcher", "Mismatch", Expr(
+	mi = ut title( "hello" ) << Matches( Outline Box( "world" ) );
+	ut assert that( Expr( mi:mismatch ), "\[DisplayBox[OutlineBox] << Get Title was "world"]\" );
+));
+
+ut test( "TitleMatcher", "Describe", Expr(
+	m = ut title( "hello" );
+	ut assert that( Expr( m << Describe ), "\[title equal to "hello"]\" );
+));
+
+ut test( "TitleMatcher", "MatchInfoSuccess", Expr(
+	mi = ut title( "hello" ) << Matches( Outline Box( "hello" ) );
+    ut assert that( Expr( mi ), ut instance of( "UtMatchInfo" ) );
+	ut assert that( Expr( mi:success ), 1 );
+));
+
+ut test( "TitleMatcher", "MatchInfoFailure", Expr(
+	mi = ut title( "hello" ) << Matches( Outline Box( "world" ) );
+    ut assert that( Expr( mi ), ut instance of( "UtMatchInfo" ) );
+	ut assert that( Expr( mi:success ), 0 );
+));
+
+ut test( "TitleMatcher", "MatcherFactory", Expr(
+	m = ut title( "hello" );
+    ut assert that( Expr( m ), ut instance of( "UtMessageMatcher" ) );
+    ut assert that( Expr( m:message ), "Get Title" );
+    ut assert that( Expr( m:description ), "title");
+));
+
+
+// ------------------------------------ ut text ------------------------------------
+ut test( "TextMatcher", "Mismatch", Expr(
+	mi = ut text( "hello" ) << Matches( Text Box( "world" ) );
+	ut assert that( Expr( mi:mismatch ), "\[DisplayBox[TextBox] << Get Text was "world"]\" );
+));
+
+ut test( "TextMatcher", "Describe", Expr(
+	m = ut text( "hello" );
+	ut assert that( Expr( m << Describe ), "\[text equal to "hello"]\" );
+));
+
+ut test( "TextMatcher", "MatchInfoSuccess", Expr(
+	mi = ut text( "hello" ) << Matches( Text Box( "hello" ) );
+    ut assert that( Expr( mi ), ut instance of( "UtMatchInfo" ) );
+	ut assert that( Expr( mi:success ), 1 );
+));
+
+ut test( "TextMatcher", "MatchInfoFailure", Expr(
+	mi = ut text( "hello" ) << Matches( Text Box( "world" ) );
+    ut assert that( Expr( mi ), ut instance of( "UtMatchInfo" ) );
+	ut assert that( Expr( mi:success ), 0 );
+));
+
+ut test( "TextMatcher", "MatcherFactory", Expr(
+	m = ut text( "hello" );
+    ut assert that( Expr( m ), ut instance of( "UtMessageMatcher" ) );
+    ut assert that( Expr( m:message ), "Get Text" );
+    ut assert that( Expr( m:description ), "text");
+));
+
+
+// ------------------------------------ ut enabled ------------------------------------
+ut test( "EnabledMatcher", "Mismatch", Expr(
+	mi = ut enabled( 0 ) << Matches( Text Box( "world" ) );
+	ut assert that( Expr( mi:mismatch ), "\[DisplayBox[TextBox] << Get Enabled was 1]\" );
+));
+
+ut test( "EnabledMatcher", "Describe", Expr(
+	m = ut enabled( 0 );
+	ut assert that( Expr( m << Describe ), "\[enabled equal to 0]\" );
+));
+
+ut test( "EnabledMatcher", "MatchInfoSuccess", Expr(
+	mi = ut enabled( 1 ) << Matches( Text Box( "hello" ) );
+    ut assert that( Expr( mi ), ut instance of( "UtMatchInfo" ) );
+	ut assert that( Expr( mi:success ), 1 );
+));
+
+ut test( "EnabledMatcher", "MatchInfoFailure", Expr(
+	mi = ut enabled( 0 ) << Matches( Text Box( "world" ) );
+    ut assert that( Expr( mi ), ut instance of( "UtMatchInfo" ) );
+	ut assert that( Expr( mi:success ), 0 );
+));
+
+ut test( "EnabledMatcher", "MatcherFactory", Expr(
+	m = ut enabled( 0 );
+    ut assert that( Expr( m ), ut instance of( "UtMessageMatcher" ) );
+    ut assert that( Expr( m:message ), "Get Enabled" );
+    ut assert that( Expr( m:description ), "enabled");
+));
+
+
+// ------------------------------------ ut class name ------------------------------------
+ut test( "ClassNameMatcher", "Mismatch", Expr(
+	mi = ut class name( "Foo" ) << Matches( Text Box( "world" ) );
+	ut assert that( Expr( mi:mismatch ), "\[DisplayBox[TextBox] << Class Name was "TextBox"]\" );
+));
+
+ut test( "ClassNameMatcher", "Describe", Expr(
+	m = ut class name( "Foo" );
+	ut assert that( Expr( m << Describe ), "\[class name equal to "Foo"]\" );
+));
+
+ut test( "ClassNameMatcher", "MatchInfoSuccess", Expr(
+	mi = ut class name( "TextBox" ) << Matches( Text Box( "hello" ) );
+    ut assert that( Expr( mi ), ut instance of( "UtMatchInfo" ) );
+	ut assert that( Expr( mi:success ), 1 );
+));
+
+ut test( "ClassNameMatcher", "MatchInfoFailure", Expr(
+	mi = ut class name( "Foo" ) << Matches( Text Box( "world" ) );
+    ut assert that( Expr( mi ), ut instance of( "UtMatchInfo" ) );
+	ut assert that( Expr( mi:success ), 0 );
+));
+
+ut test( "ClassNameMatcher", "MatcherFactory", Expr(
+	m = ut class name( "Foo" );
+    ut assert that( Expr( m ), ut instance of( "UtMessageMatcher" ) );
+    ut assert that( Expr( m:message ), "Class Name" );
+    ut assert that( Expr( m:description ), "class name");
+));
+
+
+// ------------------------------------ ut name ------------------------------------
+ut test( "TextMatcher", "Mismatch", Expr(
+	mi = ut name( "Bar" ) << Matches( New Namespace( "Foo" ) );
+	ut assert that( Expr( mi:mismatch ), "\[Namespace[Foo] << Get Name was "Foo"]\" );
+));
+
+ut test( "TextMatcher", "Describe", Expr(
+	m = ut name( "Foo" );
+	ut assert that( Expr( m << Describe ), "\[name equal to "Foo"]\" );
+));
+
+ut test( "TextMatcher", "MatchInfoSuccess", Expr(
+	mi = ut name( "Foo" ) << Matches( New Namespace( "Foo" ) );
+    ut assert that( Expr( mi ), ut instance of( "UtMatchInfo" ) );
+	ut assert that( Expr( mi:success ), 1 );
+));
+
+ut test( "TextMatcher", "MatchInfoFailure", Expr(
+	mi = ut name( "Bar" ) << Matches( New Namespace( "Foo" ) );
+    ut assert that( Expr( mi ), ut instance of( "UtMatchInfo" ) );
+	ut assert that( Expr( mi:success ), 0 );
+));
+
+ut test( "TextMatcher", "MatcherFactory", Expr(
+	m = ut name( "Foo" );
+    ut assert that( Expr( m ), ut instance of( "UtMessageMatcher" ) );
+    ut assert that( Expr( m:message ), "Get Name" );
+    ut assert that( Expr( m:description ), "name");
+));


### PR DESCRIPTION
- Allow `Scriptable` in `allowable types` within `UtTypedMatcher` sub-classes.
- Add general `ut message` factory, which is used my other `UtMessageMatcher` factories.
- `UtMessageMatcher` is now a `UtTypedMatcher`, allowing any `Scriptable` object.
- Improved failure message for `UtMessageMatcher` to include the object type and message sent.
- Added `ut enabled` matcher. Closes #40, but uses `Get Enabled` instead of `Is Enabled`.
- Added tests for all message matchers.

