### PR TITLE
Add expr eval protection to Char/Size Matchers

### DIFF
--- a/Source/Matchers/AsChar.jsl
+++ b/Source/Matchers/AsChar.jsl
@@ -1,4 +1,4 @@
-// Copyright © 2019, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
+﻿// Copyright © 2019, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 Names Default To Here( 0 );
@@ -45,5 +45,5 @@ Define Class(
 */
 ut matcher factory( "ut as char" );
 ut as char = Function( {matcher},
-	New Object( UtAsCharMatcher( ut ensure matcher( matcher ) ) );
+	New Object( UtAsCharMatcher( ut ensure matcher( Name Expr( matcher ) ) ) );
 );

--- a/Source/Matchers/Size.jsl
+++ b/Source/Matchers/Size.jsl
@@ -55,7 +55,7 @@ Define Class(
 */
 ut matcher factory( "ut length" );
 ut length = Function( {matcher},
-	New Object( UtSizeMatcher( ut ensure matcher( matcher ), "Length", "length" ) )
+	New Object( UtSizeMatcher( ut ensure matcher( Name Expr( matcher ) ), "Length", "length" ) )
 );
 
 /* 
@@ -75,7 +75,7 @@ ut length = Function( {matcher},
 */
 ut matcher factory( "ut n items" );
 ut n items = Function( {matcher},
-	New Object( UtSizeMatcher( ut ensure matcher( matcher ), "N Items", "n items" ) )
+	New Object( UtSizeMatcher( ut ensure matcher( Name Expr( matcher ) ), "N Items", "n items" ) )
 );
 
 /* 
@@ -96,7 +96,7 @@ ut n items = Function( {matcher},
 */
 ut matcher factory( "ut n cols" );
 ut n cols = Function( {matcher},
-	New Object( UtSizeMatcher( ut ensure matcher( matcher ), "N Cols", "n cols" ) )
+	New Object( UtSizeMatcher( ut ensure matcher( Name Expr( matcher ) ), "N Cols", "n cols" ) )
 );
 
 /* 
@@ -117,5 +117,5 @@ ut n cols = Function( {matcher},
 */
 ut matcher factory( "ut n rows" );
 ut n rows = Function( {matcher},
-	New Object( UtSizeMatcher( ut ensure matcher( matcher ), "N Rows", "n rows" ) )
+	New Object( UtSizeMatcher( ut ensure matcher( Name Expr( matcher ) ), "N Rows", "n rows" ) )
 );


### PR DESCRIPTION
Prevents evaluation of expressions passed as arguments to Char and Size matcher factories

- [x] I have read and agree to the [Contributor Agreement](https://github.com/sassoftware/jsl-hamcrest/blob/master/ContributorAgreement.txt)

Signed-off-by: Justin Chilton <justin.chilton@jmp.com>
