### PR TITLE
Custom functions for matchers, assertions, test, and test case functions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,7 +9,8 @@
 <!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
 
 - [ ] **I am adding a new matcher.**
-  - [ ] I have included documentation with at least one example and description.
+  - [ ] I have included documentation with at least the prototype and description in a comment above the matcher factory.
+  - [ ] I have included the prototype, description, and at least one example in the matcher factory definition for use in the Scripting Index.
   - [ ] I have added tests in `Tests/UnitTests/Matchers`.
   - [ ] I have added matcher to `Source/Matchers-Index.txt`.
   - [ ] I have added a note to `CHANGELOG.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [1.2.0]
 ### Added
+- Custom functions for matcher, assertion, test, and test case functions with examples in the Scripting Index and hover help (#58 #64).
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -131,14 +131,18 @@ function's name is what will be used in assertions. Include a call to
 		ut assert that( Expr( d ), ut day of week( 5 ) );
 		---------
 */
-ut matcher factory( "ut day of week" );
-ut day of week = Function( {val},
-	// Do necessary type checking of input variables
-	// in factory function.
-	If( !Is Number( val ),
-		Throw( "ut day of week() requires a numeric date value as the argument" ),
-	);
-	New Object( UtDayOfWeekMatcher( Name Expr( val ) ) );
+ut matcher factory( 
+  "ut day of week",
+  Expr(Function( {val},
+    // Do necessary type checking of input variables
+    // in factory function.
+    If( !Is Number( val ),
+      Throw( "ut day of week() requires a numeric date value as the argument" ),
+    );
+    New Object( UtDayOfWeekMatcher( Name Expr( val ) ) );
+  )),
+  "ut day of week( value )", //Prototype
+  "Matches based on the day of the week of a given date value." // Description
 );
 ```
 

--- a/Source/All.jsl
+++ b/Source/All.jsl
@@ -1,4 +1,4 @@
-// Copyright © 2019, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
+﻿// Copyright © 2019, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 Names Default To Here( 0 );

--- a/Source/All.jsl
+++ b/Source/All.jsl
@@ -12,8 +12,6 @@ ut include jsl files recursively( "Matchers" );
 // Reporters
 ut include jsl files recursively( "Reporters" );
 
-If( ut add custom functions,
-	Log Capture( Add Custom Functions( ut custom functions ) );
-);
+ut deploy documented functions();
 
 ut nullptr;

--- a/Source/All.jsl
+++ b/Source/All.jsl
@@ -11,3 +11,7 @@ ut include jsl files recursively( "Matchers" );
 
 // Reporters
 ut include jsl files recursively( "Reporters" );
+
+If( ut add custom functions,
+	Log Capture( Add Custom Functions( ut custom functions ) );
+);

--- a/Source/All.jsl
+++ b/Source/All.jsl
@@ -15,3 +15,5 @@ ut include jsl files recursively( "Reporters" );
 If( ut add custom functions,
 	Log Capture( Add Custom Functions( ut custom functions ) );
 );
+
+ut nullptr;

--- a/Source/Core/Core.jsl
+++ b/Source/Core/Core.jsl
@@ -5,6 +5,8 @@
 // Modeled after standard Java hamcrest and PyHamcrest
 Names Default To Here( 0 );
 
+ut package name = "JSL-Hamcrest";
+
 Include( "MatchInfo.jsl" );
 Include( "Utils.jsl" );
 
@@ -45,75 +47,90 @@ Include( "TestCase.jsl" );
 		------------------------  
 */
 ut test register assertion( "ut assert that", {test expr, matcher, label=""} );
-ut assert that = Function( {test expr, matcher, label = ""},
-	// Move args to anonymous namespace to avoid collision
-	local:_utAssertThatNS = ut move to anonymous namespace( Namespace( "local" ) );
-	
-	// Ensure that test expr is an expression
-	// This is done more for safety than for necessity.
-	//
-	// If there is no test suite to capture any unexpected
-	// throws, any throw escaping a call to ut assert that
-	// (including the implicit evaluation of its arguments) will
-	// end the entire test file and potentially skip a lot of
-	// tests. Instead, we force the user to assert only on
-	// expressions, limiting the chance of an throw escaping the
-	// call to ut assert that.
+ut define documented function(
+  "ut assert that",
+  Expr(Function( {test expr, matcher, label = ""},
+    // Move args to anonymous namespace to avoid collision
+    local:_utAssertThatNS = ut move to anonymous namespace( Namespace( "local" ) );
+    
+    // Ensure that test expr is an expression
+    // This is done more for safety than for necessity.
+    //
+    // If there is no test suite to capture any unexpected
+    // throws, any throw escaping a call to ut assert that
+    // (including the implicit evaluation of its arguments) will
+    // end the entire test file and potentially skip a lot of
+    // tests. Instead, we force the user to assert only on
+    // expressions, limiting the chance of an throw escaping the
+    // call to ut assert that.
 
-	If( !Is Expr( Name Expr( _utAssertThatNS:test expr ) ),
-		ut global reporter:add expression failure( Name Expr( _utAssertThatNS:label ) );
-		Return( 0 );
-	);
-	
-	_utAssertThatNS:matcher = ut ensure matcher( Name Expr( _utAssertThatNS:matcher ) );
-	
-	Try(
-		// After the Matches method evaluates, we are no longer worried about variable collision
-		// Use local to prevent symbols being evaluated unexpectedly ending up in the local namespace
-		// if we were to define them in the locals list in the function definition.
-		local:match info = _utAssertThatNS:matcher << Matches( Name Expr( _utAssertThatNS:test expr ) );
-		local:thrown exception = Empty();
-	,
-		local:match info = ut match info failure( "" );
-		local:thrown exception = ut get exception message( exception_msg );
-	);
-	
-	// Just in case we missed something (match info could be a missing value)
-	If( !Is Class( match info ),
-		match info = ut match info failure( "the " || (_utAssertThatNS:matcher << Get Name) || " failed to return success/failure info. the matcher itself is broken, not the test." );
-	);
-	
-	First(
-		If( !(match info << Is Success()),
-			If( Is Empty( thrown exception ),
-				ut global reporter:add failure(
-					Name Expr( _utAssertThatNS:label ),
-					Name Expr( _utAssertThatNS:test expr ),
-					_utAssertThatNS:matcher << Describe(),
-					match info << Get Mismatch(),
-					match info << Get LRE()
-				);
-				0;
-			,
-				ut global reporter:add unexpected throw(
-					Name Expr( _utAssertThatNS:label ),
-					Name Expr( _utAssertThatNS:test expr ),
-					_utAssertThatNS:matcher << Describe(),
-					thrown exception
-				);
-				0;
-			);
-		,
-			ut global reporter:add success( 
-				Name Expr( _utAssertThatNS:label ), 
-				Name Expr( _utAssertThatNS:test expr ),
-				_utAssertThatNS:matcher << Describe()
-			);
-			1;
-		),
-		Delete Namespaces( Force( 1 ), _utAssertThatNS );
-	);
-	
+    If( !Is Expr( Name Expr( _utAssertThatNS:test expr ) ),
+      ut global reporter:add expression failure( Name Expr( _utAssertThatNS:label ) );
+      Return( 0 );
+    );
+    
+    _utAssertThatNS:matcher = ut ensure matcher( Name Expr( _utAssertThatNS:matcher ) );
+    
+    Try(
+      // After the Matches method evaluates, we are no longer worried about variable collision
+      // Use local to prevent symbols being evaluated unexpectedly ending up in the local namespace
+      // if we were to define them in the locals list in the function definition.
+      local:match info = _utAssertThatNS:matcher << Matches( Name Expr( _utAssertThatNS:test expr ) );
+      local:thrown exception = Empty();
+    ,
+      local:match info = ut match info failure( "" );
+      local:thrown exception = ut get exception message( exception_msg );
+    );
+    
+    // Just in case we missed something (match info could be a missing value)
+    If( !Is Class( match info ),
+      match info = ut match info failure( "the " || (_utAssertThatNS:matcher << Get Name) || " failed to return success/failure info. the matcher itself is broken, not the test." );
+    );
+    
+    First(
+      If( !(match info << Is Success()),
+        If( Is Empty( thrown exception ),
+          ut global reporter:add failure(
+            Name Expr( _utAssertThatNS:label ),
+            Name Expr( _utAssertThatNS:test expr ),
+            _utAssertThatNS:matcher << Describe(),
+            match info << Get Mismatch(),
+            match info << Get LRE()
+          );
+          0;
+        ,
+          ut global reporter:add unexpected throw(
+            Name Expr( _utAssertThatNS:label ),
+            Name Expr( _utAssertThatNS:test expr ),
+            _utAssertThatNS:matcher << Describe(),
+            thrown exception
+          );
+          0;
+        );
+      ,
+        ut global reporter:add success( 
+          Name Expr( _utAssertThatNS:label ), 
+          Name Expr( _utAssertThatNS:test expr ),
+          _utAssertThatNS:matcher << Describe()
+        );
+        1;
+      ),
+      Delete Namespaces( Force( 1 ), _utAssertThatNS );
+    );
+    
+  )),
+  "\[ut assert that( test expr, matcher, <label=""> )]\",
+  "Assertion function that accepts matchers to determine successes and failures.",
+  {{
+    "Simple",
+    "\[
+// Without a matcher, it defaults to the ut equal to() matcher
+ut assert that( Expr( 5 + 5 ), 10 );
+// The above is equivalent to:
+ut assert that( Expr( 5 + 5 ), ut equal to( 10 ) );
+// Some matchers accept inner matchers
+ut assert that( Expr( Show( 5 + 5 ) ), ut log is( ut equal to ignoring whitespace( "5 + 5 = 10;" ) ) );]\"
+  }}
 );
 
 /*	Function: ut assert value
@@ -139,8 +156,16 @@ ut assert that = Function( {test expr, matcher, label = ""},
 		matcher - matcher object
 		label - label for this assertion
 */
-ut assert value = Function( {val, matcher, label=""},
-	ut assert that( ut expr literal( Name Expr( val ) ), Name Expr( matcher ), Name Expr( label ) );
+ut define documented function(
+  "ut assert value",
+  Expr(Function( {val, matcher, label=""},
+    ut assert that( ut expr literal( Name Expr( val ) ), Name Expr( matcher ), Name Expr( label ) );
+  )),
+  "ut assert value( value, matcher, <label> )",
+  "Assertion function that allows evaluation of test values to take place at call site rather than within the matchers. This means that the ut throws and ut no throw matchers should not be used with ut assert value.\!n\!n" ||
+  "This function is helpful when you are not worried about error catching and want to reduce the risk of name resolution issues due to being evaluated within a matcher.\!n\!n" ||
+	"It is recommended to only use ut assert value within a ut test body so that errors are caught and you do not experience errors that prevent other tests from being run.",
+  {{"Simple", x = 5; ut assert value(x, 5)}}
 );
 
 // Constant: ut global reporter

--- a/Source/Core/Core.jsl
+++ b/Source/Core/Core.jsl
@@ -44,93 +44,93 @@ Include( "TestCase.jsl" );
 		ut assert that( Expr( 5 + 5 ), ut equal to( 10 ) );
 		// Some matchers accept inner matchers
 		ut assert that( Expr( Show( 5 + 5 ) ), ut log is( ut equal to ignoring whitespace( "5 + 5 = 10;" ) ) );
-		------------------------  
+		------------------------	
 */
 ut test register assertion( "ut assert that", {test expr, matcher, label=""} );
 ut define documented function(
-  "ut assert that",
-  Expr(Function( {test expr, matcher, label = ""},
-    // Move args to anonymous namespace to avoid collision
-    local:_utAssertThatNS = ut move to anonymous namespace( Namespace( "local" ) );
-    
-    // Ensure that test expr is an expression
-    // This is done more for safety than for necessity.
-    //
-    // If there is no test suite to capture any unexpected
-    // throws, any throw escaping a call to ut assert that
-    // (including the implicit evaluation of its arguments) will
-    // end the entire test file and potentially skip a lot of
-    // tests. Instead, we force the user to assert only on
-    // expressions, limiting the chance of an throw escaping the
-    // call to ut assert that.
+	"ut assert that",
+	Expr(Function( {test expr, matcher, label = ""},
+		// Move args to anonymous namespace to avoid collision
+		local:_utAssertThatNS = ut move to anonymous namespace( Namespace( "local" ) );
+		
+		// Ensure that test expr is an expression
+		// This is done more for safety than for necessity.
+		//
+		// If there is no test suite to capture any unexpected
+		// throws, any throw escaping a call to ut assert that
+		// (including the implicit evaluation of its arguments) will
+		// end the entire test file and potentially skip a lot of
+		// tests. Instead, we force the user to assert only on
+		// expressions, limiting the chance of an throw escaping the
+		// call to ut assert that.
 
-    If( !Is Expr( Name Expr( _utAssertThatNS:test expr ) ),
-      ut global reporter:add expression failure( Name Expr( _utAssertThatNS:label ) );
-      Return( 0 );
-    );
-    
-    _utAssertThatNS:matcher = ut ensure matcher( Name Expr( _utAssertThatNS:matcher ) );
-    
-    Try(
-      // After the Matches method evaluates, we are no longer worried about variable collision
-      // Use local to prevent symbols being evaluated unexpectedly ending up in the local namespace
-      // if we were to define them in the locals list in the function definition.
-      local:match info = _utAssertThatNS:matcher << Matches( Name Expr( _utAssertThatNS:test expr ) );
-      local:thrown exception = Empty();
-    ,
-      local:match info = ut match info failure( "" );
-      local:thrown exception = ut get exception message( exception_msg );
-    );
-    
-    // Just in case we missed something (match info could be a missing value)
-    If( !Is Class( match info ),
-      match info = ut match info failure( "the " || (_utAssertThatNS:matcher << Get Name) || " failed to return success/failure info. the matcher itself is broken, not the test." );
-    );
-    
-    First(
-      If( !(match info << Is Success()),
-        If( Is Empty( thrown exception ),
-          ut global reporter:add failure(
-            Name Expr( _utAssertThatNS:label ),
-            Name Expr( _utAssertThatNS:test expr ),
-            _utAssertThatNS:matcher << Describe(),
-            match info << Get Mismatch(),
-            match info << Get LRE()
-          );
-          0;
-        ,
-          ut global reporter:add unexpected throw(
-            Name Expr( _utAssertThatNS:label ),
-            Name Expr( _utAssertThatNS:test expr ),
-            _utAssertThatNS:matcher << Describe(),
-            thrown exception
-          );
-          0;
-        );
-      ,
-        ut global reporter:add success( 
-          Name Expr( _utAssertThatNS:label ), 
-          Name Expr( _utAssertThatNS:test expr ),
-          _utAssertThatNS:matcher << Describe()
-        );
-        1;
-      ),
-      Delete Namespaces( Force( 1 ), _utAssertThatNS );
-    );
-    
-  )),
-  "\[ut assert that( test expr, matcher, <label=""> )]\",
-  "Assertion function that accepts matchers to determine successes and failures.",
-  {{
-    "Simple",
-    "\[
+		If( !Is Expr( Name Expr( _utAssertThatNS:test expr ) ),
+			ut global reporter:add expression failure( Name Expr( _utAssertThatNS:label ) );
+			Return( 0 );
+		);
+		
+		_utAssertThatNS:matcher = ut ensure matcher( Name Expr( _utAssertThatNS:matcher ) );
+		
+		Try(
+			// After the Matches method evaluates, we are no longer worried about variable collision
+			// Use local to prevent symbols being evaluated unexpectedly ending up in the local namespace
+			// if we were to define them in the locals list in the function definition.
+			local:match info = _utAssertThatNS:matcher << Matches( Name Expr( _utAssertThatNS:test expr ) );
+			local:thrown exception = Empty();
+		,
+			local:match info = ut match info failure( "" );
+			local:thrown exception = ut get exception message( exception_msg );
+		);
+		
+		// Just in case we missed something (match info could be a missing value)
+		If( !Is Class( match info ),
+			match info = ut match info failure( "the " || (_utAssertThatNS:matcher << Get Name) || " failed to return success/failure info. the matcher itself is broken, not the test." );
+		);
+		
+		First(
+			If( !(match info << Is Success()),
+				If( Is Empty( thrown exception ),
+					ut global reporter:add failure(
+						Name Expr( _utAssertThatNS:label ),
+						Name Expr( _utAssertThatNS:test expr ),
+						_utAssertThatNS:matcher << Describe(),
+						match info << Get Mismatch(),
+						match info << Get LRE()
+					);
+					0;
+				,
+					ut global reporter:add unexpected throw(
+						Name Expr( _utAssertThatNS:label ),
+						Name Expr( _utAssertThatNS:test expr ),
+						_utAssertThatNS:matcher << Describe(),
+						thrown exception
+					);
+					0;
+				);
+			,
+				ut global reporter:add success( 
+					Name Expr( _utAssertThatNS:label ), 
+					Name Expr( _utAssertThatNS:test expr ),
+					_utAssertThatNS:matcher << Describe()
+				);
+				1;
+			),
+			Delete Namespaces( Force( 1 ), _utAssertThatNS );
+		);
+		
+	)),
+	"\[ut assert that( test expr, matcher, <label=""> )]\",
+	"Assertion function that accepts matchers to determine successes and failures.",
+	{{
+		"Simple",
+		"\[
 // Without a matcher, it defaults to the ut equal to() matcher
 ut assert that( Expr( 5 + 5 ), 10 );
 // The above is equivalent to:
 ut assert that( Expr( 5 + 5 ), ut equal to( 10 ) );
 // Some matchers accept inner matchers
 ut assert that( Expr( Show( 5 + 5 ) ), ut log is( ut equal to ignoring whitespace( "5 + 5 = 10;" ) ) );]\"
-  }}
+	}}
 );
 
 /*	Function: ut assert value
@@ -152,20 +152,20 @@ ut assert that( Expr( Show( 5 + 5 ) ), ut log is( ut equal to ignoring whitespac
 	
 	Arguments:
 		val - an already evaluated value that will be used within 
-		      a matcher literally
+					a matcher literally
 		matcher - matcher object
 		label - label for this assertion
 */
 ut define documented function(
-  "ut assert value",
-  Expr(Function( {val, matcher, label=""},
-    ut assert that( ut expr literal( Name Expr( val ) ), Name Expr( matcher ), Name Expr( label ) );
-  )),
-  "ut assert value( value, matcher, <label> )",
-  "Assertion function that allows evaluation of test values to take place at call site rather than within the matchers. This means that the ut throws and ut no throw matchers should not be used with ut assert value.\!n\!n" ||
-  "This function is helpful when you are not worried about error catching and want to reduce the risk of name resolution issues due to being evaluated within a matcher.\!n\!n" ||
+	"ut assert value",
+	Expr(Function( {val, matcher, label=""},
+		ut assert that( ut expr literal( Name Expr( val ) ), Name Expr( matcher ), Name Expr( label ) );
+	)),
+	"ut assert value( value, matcher, <label> )",
+	"Assertion function that allows evaluation of test values to take place at call site rather than within the matchers. This means that the ut throws and ut no throw matchers should not be used with ut assert value.\!n\!n" ||
+	"This function is helpful when you are not worried about error catching and want to reduce the risk of name resolution issues due to being evaluated within a matcher.\!n\!n" ||
 	"It is recommended to only use ut assert value within a ut test body so that errors are caught and you do not experience errors that prevent other tests from being run.",
-  {{"Simple", x = 5; ut assert value(x, 5)}}
+	{{"Simple", x = 5; ut assert value(x, 5)}}
 );
 
 // Constant: ut global reporter

--- a/Source/Core/Matchers/EqualTo.jsl
+++ b/Source/Core/Matchers/EqualTo.jsl
@@ -349,7 +349,7 @@ Define Class(
 			ut is a matcher( valueData["matcher"] ),
 				match info = valueData["matcher"]:matches( Insert( Expr( Expr() ), actualData["expression"] ) );
 				
-				If(  // Just in case we missed something (match info could be a missing value)
+				If(	// Just in case we missed something (match info could be a missing value)
 					!Is Class( match info ),
 						match info = ut match info failure( "the " || (valueData["matcher"] << Get Name) || " failed to return success/failure info. the matcher itself is broken, not the test." );
 				,
@@ -392,7 +392,7 @@ Define Class(
 		,
 			//else
 				If( valueData["required"], 
-					Return(  ::ut match info failure( Eval Insert( "\[ required head expressions did not match (Actual=^Char( actualData["head"] )^, Expected=^Char( valueData["head"] )^)]\" ) ) ), 
+					Return( ::ut match info failure( Eval Insert( "\[ required head expressions did not match (Actual=^Char( actualData["head"] )^, Expected=^Char( valueData["head"] )^)]\" ) ) ), 
 					Return( New Object( Ut Match Info( -1, "optional" ) ) )
 				);
 		);
@@ -438,7 +438,7 @@ Define Class(
 		ut expression matches(
 			Expr(
 				Graph Builder(
-					ut optional( size( ut  wild(), ut wild() ) ),
+					ut optional( size( ut wild(), ut wild() ) ),
 					Show ControlPanel( 0 ),
 					Variables( X( :height ), Y( :weight ), Overlay( :sex ) ),
 					Elements( Points( X, Y, Legend( 1 ) ), Smoother( X, Y, Legend( 2 ) ) )
@@ -459,41 +459,41 @@ Define Class(
 	> ut assert that( Expr( Expr( x << Get Name(); b = 10; c; ) ), ut expression matches( Expr( x << Get Name; b = 10; c; ) ) );
 */
 ut matcher factory( "ut expression matches",
-  Expr(Function({valueExpression},
-    {obj},
-    obj = New Object( UtExpressionCompositeMatcher() );
-    obj:value = Name Expr( valueExpression );
-    obj;
-  )),
-  "",
-  "",
-  {
-    {
-      "Expression",
-      ut assert that(
-        Expr( gb << get script ),
-        ut expression matches(
-          Expr(
-            Graph Builder(
-              ut optional( size( ut  wild(), ut wild() ) ),
-              Show ControlPanel( 0 ),
-              Variables( X( :height ), Y( :weight ), Overlay( :sex ) ),
-              Elements( Points( X, Y, Legend( 1 ) ), Smoother( X, Y, Legend( 2 ) ) )
-            )
-          )
-        )
-      );
-    },
-    {
-      "List",
-      ut assert that(
-        Expr( {400, c( [1,5] ), x( z( "TEST", 1 ) )} ),
-        ut expression matches(
-          {ut less than( 500 ), c( [1,5] ), x( z( ut equal to ignoring case( "test" ), ut greater than( 0 ) ) )}
-        )
-      );
-    }
-  }
+	Expr(Function({valueExpression},
+		{obj},
+		obj = New Object( UtExpressionCompositeMatcher() );
+		obj:value = Name Expr( valueExpression );
+		obj;
+	)),
+	"",
+	"",
+	{
+		{
+			"Expression",
+			ut assert that(
+				Expr( gb << get script ),
+				ut expression matches(
+					Expr(
+						Graph Builder(
+							ut optional( size( ut wild(), ut wild() ) ),
+							Show ControlPanel( 0 ),
+							Variables( X( :height ), Y( :weight ), Overlay( :sex ) ),
+							Elements( Points( X, Y, Legend( 1 ) ), Smoother( X, Y, Legend( 2 ) ) )
+						)
+					)
+				)
+			);
+		},
+		{
+			"List",
+			ut assert that(
+				Expr( {400, c( [1,5] ), x( z( "TEST", 1 ) )} ),
+				ut expression matches(
+					{ut less than( 500 ), c( [1,5] ), x( z( ut equal to ignoring case( "test" ), ut greater than( 0 ) ) )}
+				)
+			);
+		}
+	}
 );
 
 /* 
@@ -514,15 +514,15 @@ ut matcher factory( "ut expression matches",
 		> ut assert that( Expr( Expr( 5 + 5 ) ), ut equal to expression( Expr( 5 + 5 ) ) );
 */
 ut matcher factory( "ut equal to expression",
-  Expr(Function({val},
-    {obj},
-    obj = New Object( UtEqualToExpressionMatcher() );
-    obj:value = Name Expr( val );
-    obj;
-  )),
-  "ut equal to expression( value )",
-  "Compares the expression using the built-in == operator. Available since ut equal to() matcher uses ut expression matches() by default.",
-  {{"Simple", ut assert that( Expr( Expr( 5 + 5 ) ), ut equal to expression( Expr( 5 + 5 ) ) ); }}
+	Expr(Function({val},
+		{obj},
+		obj = New Object( UtEqualToExpressionMatcher() );
+		obj:value = Name Expr( val );
+		obj;
+	)),
+	"ut equal to expression( value )",
+	"Compares the expression using the built-in == operator. Available since ut equal to() matcher uses ut expression matches() by default.",
+	{{"Simple", ut assert that( Expr( Expr( 5 + 5 ) ), ut equal to expression( Expr( 5 + 5 ) ) ); }}
 );
 
 /* 	
@@ -546,59 +546,59 @@ ut matcher factory( "ut equal to expression",
 		> ut assert that( Expr( "test" || "string" ), ut equal to( "teststring" ) );
 */
 ut matcher factory( "ut equal to",
-  Expr(Function( {val},
-    {obj},
-    obj = Match( Type( Name Expr( val ) ),
-      "Number",
-        New Object( UtEqualToNumberMatcher() );
-    ,
-      "Integer",
-        New Object( UtEqualToNumberMatcher() );
-    ,
-      "Matrix",
-        New Object( UtEqualToMatrixMatcher() );
-    ,
-      "List",
-        New Object( UtEqualToListMatcher() );
-    ,
-      "Associative Array",
-        New Object( UtEqualToAssociativeArrayMatcher() );
-    ,
-      "Expression",
-        // only use the composite matcher if this expression has children
-        If( NArg( val ) > 0,
-          New Object( UtExpressionCompositeMatcher() ),
-          New Object( UtEqualToExpressionMatcher() )
-        );
-    ,
-      "Name",
-        // only use the composite matcher if this name has children
-        If( NArg( val ) > 0,
-          New Object( UtExpressionCompositeMatcher() ),
-          New Object( UtEqualToExpressionMatcher() )
-        );
-    ,
-      "Function",
-        New Object( UtEqualToExpressionMatcher() );
-    ,
-      "Class",
-        New Object( UtEqualToClassMatcher() );
-    ,
-      "Namespace",
-        New Object( UtEqualToNamespaceMatcher() )
-    ,
-      // default
-        New Object( UtEqualToMatcher() );
-    );
-    
-    obj:value = Name Expr( val );
-    obj;
-  )),
-  "ut equal to( value )",
-  "Compares objects to see if they are equal to each other. Expressions and names with arguments default to the ut expression matches() matcher.",
-  {{
-    "Simple",
-    "\[
+	Expr(Function( {val},
+		{obj},
+		obj = Match( Type( Name Expr( val ) ),
+			"Number",
+				New Object( UtEqualToNumberMatcher() );
+		,
+			"Integer",
+				New Object( UtEqualToNumberMatcher() );
+		,
+			"Matrix",
+				New Object( UtEqualToMatrixMatcher() );
+		,
+			"List",
+				New Object( UtEqualToListMatcher() );
+		,
+			"Associative Array",
+				New Object( UtEqualToAssociativeArrayMatcher() );
+		,
+			"Expression",
+				// only use the composite matcher if this expression has children
+				If( NArg( val ) > 0,
+					New Object( UtExpressionCompositeMatcher() ),
+					New Object( UtEqualToExpressionMatcher() )
+				);
+		,
+			"Name",
+				// only use the composite matcher if this name has children
+				If( NArg( val ) > 0,
+					New Object( UtExpressionCompositeMatcher() ),
+					New Object( UtEqualToExpressionMatcher() )
+				);
+		,
+			"Function",
+				New Object( UtEqualToExpressionMatcher() );
+		,
+			"Class",
+				New Object( UtEqualToClassMatcher() );
+		,
+			"Namespace",
+				New Object( UtEqualToNamespaceMatcher() )
+		,
+			// default
+				New Object( UtEqualToMatcher() );
+		);
+		
+		obj:value = Name Expr( val );
+		obj;
+	)),
+	"ut equal to( value )",
+	"Compares objects to see if they are equal to each other. Expressions and names with arguments default to the ut expression matches() matcher.",
+	{{
+		"Simple",
+		"\[
 // Numbers
 ut assert that( Expr( 5 + 5 ), ut equal to( 10 ) );
 // Matrices
@@ -610,5 +610,5 @@ ut assert that( Expr( Expr( 5 + 5 ) ), ut equal to( Expr( 5 + 5 ) ) );
 // Strings
 ut assert that( Expr( "test" || "string" ), ut equal to( "teststring" ) );
 ]\"
-  }}
+	}}
 );

--- a/Source/Core/Matchers/EqualTo.jsl
+++ b/Source/Core/Matchers/EqualTo.jsl
@@ -465,20 +465,21 @@ ut matcher factory( "ut expression matches",
 		obj:value = Name Expr( valueExpression );
 		obj;
 	)),
-	"",
-	"",
+	"ut expression matches( expression )",
+	"Compare the actual expression to and expected expression, which itself can contain matchers or optional tokens. This can be very useful for size arguments that change based on the machine settings/font size or if there is a small difference in output between operating systems. This is the default matcher for expressions and and names which contain arguments.",
 	{
 		{
 			"Expression",
+			dt = Open( "$SAMPLE_DATA\Big Class.jmp" );
+			gb = dt << Run Script( "Graph Builder Smoother Line" );
 			ut assert that(
 				Expr( gb << get script ),
 				ut expression matches(
 					Expr(
 						Graph Builder(
-							ut optional( size( ut wild(), ut wild() ) ),
 							Show ControlPanel( 0 ),
 							Variables( X( :height ), Y( :weight ), Overlay( :sex ) ),
-							Elements( Points( X, Y, Legend( 1 ) ), Smoother( X, Y, Legend( 2 ) ) )
+							Elements( Points( X, Y, Legend( 1 ) ), Smoother( X, Y, Legend( ut wild() ) ) )
 						)
 					)
 				)

--- a/Source/Core/Matchers/EqualTo.jsl
+++ b/Source/Core/Matchers/EqualTo.jsl
@@ -420,7 +420,7 @@ Define Class(
 		change based on the machine settings/font size or if there is a small difference in 
 		output between operating systems.
 		
-		This is the default matcher for expressions and and names which contain arguments.
+		This is the default matcher for expressions and names which contain arguments.
 
 		Factory function for <UtExpressionCompositeMatcher>.
 
@@ -466,7 +466,7 @@ ut matcher factory( "ut expression matches",
 		obj;
 	)),
 	"ut expression matches( expression )",
-	"Compare the actual expression to and expected expression, which itself can contain matchers or optional tokens. This can be very useful for size arguments that change based on the machine settings/font size or if there is a small difference in output between operating systems. This is the default matcher for expressions and and names which contain arguments.",
+	"Compare the actual expression to and expected expression, which itself can contain matchers or optional tokens. This can be very useful for size arguments that change based on the machine settings/font size or if there is a small difference in output between operating systems. This is the default matcher for expressions and names which contain arguments.",
 	{
 		{
 			"Expression",

--- a/Source/Core/Matchers/EqualTo.jsl
+++ b/Source/Core/Matchers/EqualTo.jsl
@@ -458,12 +458,42 @@ Define Class(
 	-------------------------------
 	> ut assert that( Expr( Expr( x << Get Name(); b = 10; c; ) ), ut expression matches( Expr( x << Get Name; b = 10; c; ) ) );
 */
-ut matcher factory( "ut expression matches" );
-ut expression matches = Function({valueExpression},
-	{obj},
-	obj = New Object( UtExpressionCompositeMatcher() );
-	obj:value = Name Expr( valueExpression );
-	obj;
+ut matcher factory( "ut expression matches",
+  Expr(Function({valueExpression},
+    {obj},
+    obj = New Object( UtExpressionCompositeMatcher() );
+    obj:value = Name Expr( valueExpression );
+    obj;
+  )),
+  "",
+  "",
+  {
+    {
+      "Expression",
+      ut assert that(
+        Expr( gb << get script ),
+        ut expression matches(
+          Expr(
+            Graph Builder(
+              ut optional( size( ut  wild(), ut wild() ) ),
+              Show ControlPanel( 0 ),
+              Variables( X( :height ), Y( :weight ), Overlay( :sex ) ),
+              Elements( Points( X, Y, Legend( 1 ) ), Smoother( X, Y, Legend( 2 ) ) )
+            )
+          )
+        )
+      );
+    },
+    {
+      "List",
+      ut assert that(
+        Expr( {400, c( [1,5] ), x( z( "TEST", 1 ) )} ),
+        ut expression matches(
+          {ut less than( 500 ), c( [1,5] ), x( z( ut equal to ignoring case( "test" ), ut greater than( 0 ) ) )}
+        )
+      );
+    }
+  }
 );
 
 /* 
@@ -483,12 +513,16 @@ ut expression matches = Function({valueExpression},
 
 		> ut assert that( Expr( Expr( 5 + 5 ) ), ut equal to expression( Expr( 5 + 5 ) ) );
 */
-ut matcher factory( "ut equal to expression" );
-ut equal to expression = Function({val},
-	{obj},
-	obj = New Object( UtEqualToExpressionMatcher() );
-	obj:value = Name Expr( val );
-	obj;
+ut matcher factory( "ut equal to expression",
+  Expr(Function({val},
+    {obj},
+    obj = New Object( UtEqualToExpressionMatcher() );
+    obj:value = Name Expr( val );
+    obj;
+  )),
+  "ut equal to expression( value )",
+  "Compares the expression using the built-in == operator. Available since ut equal to() matcher uses ut expression matches() by default.",
+  {{"Simple", ut assert that( Expr( Expr( 5 + 5 ) ), ut equal to expression( Expr( 5 + 5 ) ) ); }}
 );
 
 /* 	
@@ -511,52 +545,70 @@ ut equal to expression = Function({val},
 		> ut assert that( Expr( Expr( 5 + 5 ) ), ut equal to( Expr( 5 + 5 ) ) );
 		> ut assert that( Expr( "test" || "string" ), ut equal to( "teststring" ) );
 */
-ut matcher factory( "ut equal to" );
-ut equal to = Function( {val},
-	{obj},
-	obj = Match( Type( Name Expr( val ) ),
-		"Number",
-			New Object( UtEqualToNumberMatcher() );
-	,
-		"Integer",
-			New Object( UtEqualToNumberMatcher() );
-	,
-		"Matrix",
-			New Object( UtEqualToMatrixMatcher() );
-	,
-		"List",
-			New Object( UtEqualToListMatcher() );
-	,
-		"Associative Array",
-			New Object( UtEqualToAssociativeArrayMatcher() );
-	,
-		"Expression",
-			// only use the composite matcher if this expression has children
-			If( NArg( val ) > 0,
-				New Object( UtExpressionCompositeMatcher() ),
-				New Object( UtEqualToExpressionMatcher() )
-			);
-	,
-		"Name",
-			// only use the composite matcher if this name has children
-			If( NArg( val ) > 0,
-				New Object( UtExpressionCompositeMatcher() ),
-				New Object( UtEqualToExpressionMatcher() )
-			);
-	,
-		"Function",
-			New Object( UtEqualToExpressionMatcher() );
-	,
-		"Class",
-			New Object( UtEqualToClassMatcher() );
-	,
-		"Namespace",
-			New Object( UtEqualToNamespaceMatcher() )
-	,
-		// default
-			New Object( UtEqualToMatcher() );
-	);
-	
-	obj:value = Name Expr( val );
-	obj;
+ut matcher factory( "ut equal to",
+  Expr(Function( {val},
+    {obj},
+    obj = Match( Type( Name Expr( val ) ),
+      "Number",
+        New Object( UtEqualToNumberMatcher() );
+    ,
+      "Integer",
+        New Object( UtEqualToNumberMatcher() );
+    ,
+      "Matrix",
+        New Object( UtEqualToMatrixMatcher() );
+    ,
+      "List",
+        New Object( UtEqualToListMatcher() );
+    ,
+      "Associative Array",
+        New Object( UtEqualToAssociativeArrayMatcher() );
+    ,
+      "Expression",
+        // only use the composite matcher if this expression has children
+        If( NArg( val ) > 0,
+          New Object( UtExpressionCompositeMatcher() ),
+          New Object( UtEqualToExpressionMatcher() )
+        );
+    ,
+      "Name",
+        // only use the composite matcher if this name has children
+        If( NArg( val ) > 0,
+          New Object( UtExpressionCompositeMatcher() ),
+          New Object( UtEqualToExpressionMatcher() )
+        );
+    ,
+      "Function",
+        New Object( UtEqualToExpressionMatcher() );
+    ,
+      "Class",
+        New Object( UtEqualToClassMatcher() );
+    ,
+      "Namespace",
+        New Object( UtEqualToNamespaceMatcher() )
+    ,
+      // default
+        New Object( UtEqualToMatcher() );
+    );
+    
+    obj:value = Name Expr( val );
+    obj;
+  )),
+  "ut equal to( value )",
+  "Compares objects to see if they are equal to each other. Expressions and names with arguments default to the ut expression matches() matcher.",
+  {{
+    "Simple",
+    "\[
+// Numbers
+ut assert that( Expr( 5 + 5 ), ut equal to( 10 ) );
+// Matrices
+ut assert that( Expr( [1] || [1] ), ut equal to( [1 1] ) );
+// Associative Arrays
+ut assert that( Expr( Associative Array( {{1,2}}) ), ut equal to( [1=>2] ) );
+// Expressions
+ut assert that( Expr( Expr( 5 + 5 ) ), ut equal to( Expr( 5 + 5 ) ) );
+// Strings
+ut assert that( Expr( "test" || "string" ), ut equal to( "teststring" ) );
+]\"
+  }}
 );

--- a/Source/Core/Matchers/Is.jsl
+++ b/Source/Core/Matchers/Is.jsl
@@ -42,10 +42,13 @@ Define Class(
 		matcher - any object
 
 	Examples:
-
 		> ut assert that( Expr( 5 + 5 ), ut is( ut equal to( 10 ) ) );
 */
-ut matcher factory( "ut is" );
-ut is = Function( {matcher},
-	New Object( UtIsMatcher( ut ensure matcher( Name Expr( matcher ) ) ) )
+ut matcher factory( "ut is",
+  Expr(Function( {matcher},
+    New Object( UtIsMatcher( ut ensure matcher( Name Expr( matcher ) ) ) )
+  )),
+  "ut is( matcher )",
+  "\[A forwarding matcher to help when an "is" would help the assertion read more naturally.]\",
+  {{"Simple", ut assert that( Expr( 5 + 5 ), ut is( ut equal to( 10 ) ) ); }}
 );

--- a/Source/Core/Matchers/Is.jsl
+++ b/Source/Core/Matchers/Is.jsl
@@ -45,10 +45,10 @@ Define Class(
 		> ut assert that( Expr( 5 + 5 ), ut is( ut equal to( 10 ) ) );
 */
 ut matcher factory( "ut is",
-  Expr(Function( {matcher},
-    New Object( UtIsMatcher( ut ensure matcher( Name Expr( matcher ) ) ) )
-  )),
-  "ut is( matcher )",
-  "\[A forwarding matcher to help when an "is" would help the assertion read more naturally.]\",
-  {{"Simple", ut assert that( Expr( 5 + 5 ), ut is( ut equal to( 10 ) ) ); }}
+	Expr(Function( {matcher},
+		New Object( UtIsMatcher( ut ensure matcher( Name Expr( matcher ) ) ) )
+	)),
+	"ut is( matcher )",
+	"\[A forwarding matcher to help when an "is" would help the assertion read more naturally.]\",
+	{{"Simple", ut assert that( Expr( 5 + 5 ), ut is( ut equal to( 10 ) ) ); }}
 );

--- a/Source/Core/TestCase.jsl
+++ b/Source/Core/TestCase.jsl
@@ -101,8 +101,7 @@ Define Class(
 	Function: ut test case
 		Used to isolate a test case from other code in the test file.
 		Also prepends the name of the test and assert number to the beginning
-		of the labels for ut assert, ut assert digits, ut assert LRE, and
-		ut assert that.
+		of the labels for ut assert that.
 		
 	Arguments:
 		name - Name of the test case to be used as part of the label.
@@ -148,15 +147,57 @@ Define Class(
 		);
 		---------------------------
 */
-ut test case = Function({name},
-	{obj},
-	obj = New Object( UtTestCaseFixture( name ) );
-	
-	// Set a reference to itself.
-	obj:self = local:obj;
-	
-	// return the object
-	obj
+ut define documented function(
+  "ut test case",
+  Expr(Function({name},
+    {obj},
+    obj = New Object( UtTestCaseFixture( name ) );
+    
+    // Set a reference to itself.
+    obj:self = local:obj;
+    
+    // return the object
+    obj
+  )),
+  "ut test case( test case name )",
+  "Used to isolate a test case from other code in the test file. Also prepends the name of the test and assert number to the beginning of the labels for ut assert that.",
+  {
+    {
+      "Setup/Teardown",
+      test case = ut test case( "Sample test case" )
+        << Setup( Expr( dt = Open( "$SAMPLE_DATA\Big Class.jmp" ); ) )
+        << Teardown( Expr( Close( dt, NoSave ); ) );
+        
+      ut test( test case, "test level comment",
+        Expr(
+          dt << new column( "Test", Formula( Row() ) );
+          ut assert that( Expr( dt:Test << Get Values ), (1::40)`, "my assert level comment" ); 
+        )
+      );
+      ut test( test case, "test level comment",
+        Expr(
+          dt << new column( "Test", Value Labels( {0 = "N", 1 = "Y"} ) );
+          ut assert that( Expr( dt:Test << Get Property( "Value Labels" ) ), Expr( Value Labels( {0 = "N", 1 = "Y"} ) ), "my assert level comment" );
+        )
+      );
+    },
+    {
+      "Repeating Labels",
+      test case = ut test case( "Sample test case" );
+      ut test( test case, "test level comment - addition",
+        Expr(
+          ut assert that( Expr( 5 + 6 ), 11 );
+          ut assert that( Expr( 5 + 5 ), 10, "my assert level comment" ); 
+        )
+      );
+      ut test( test case, "test level comment - subtraction",
+        Expr(
+          ut assert that( Expr( 5 - 6 ), -1 );
+          ut assert that( Expr( 5 - 5 ), 0, "my assert level comment" ); 
+        )
+      );
+    }
+  }
 );
 
 /* 
@@ -322,175 +363,192 @@ ut test filtering reporter = New Object("UtSuccessFilteringReporter"(Empty()));
 		);
 		---------------------------
 */
-ut test = Function({test case, test name, test expr, log benchmark = ut log bench()},
-	
-	// Validate inputs
-	If( 
-		Is String( Name Expr( test case ) ),
-			test case = ::ut test case( test case );
-	,
-		!Is Class( Name Expr( test case ) ),
-			Throw( "ut test() requires the first argument to be a string or test case object." );
-	,
-		test case << Get Name != "UtTestCaseFixture",
-			Throw( "ut test() requires the first argument to be a string or test case object." );
-	);
-	
-	If( !Is String( Name Expr( test name ) ),
-		Throw( "ut test() requires the second argument to be a string." );
-	);
-	
-	If( !Is Expr( Name Expr( test expr ) ),
-		Throw( "ut test() requires the third argument to be an expression." );
-	);
-	
-	If( !Is Class( Name Expr( log benchmark ) ),
-			Throw( "ut test() requires the optional fourth argument to be ut log bench( < 0 | 1 >, < string matcher > )" );
-	,
-		log benchmark << Get Name != "UtLogBenchmark",
-			Throw( "ut test() requires the optional fourth argument to be ut log bench( < 0 | 1 >, < string matcher > )" );
-	);
-	
-	// Create an anonymous namespace that is not in the current
-	// dynamic scoping hierarchy.
-	// This variable is the only thing that could potentially collide 
-	// with a test.
-	local:_utTestNS = ut move to anonymous namespace( Namespace( "local" ) );
-	
-	// get the symbols defined before running the test case
-	_utTestNS:before symbols = ::ut get symbol information();
-	
-	_utTestNS:n asserts = 0;
-	_utTestNS:results = {};
-	
-	For( _utTestNS:iAssertion = 1, _utTestNS:iAssertion <= N Items( ut test registered assertions ), _utTestNS:iAssertion++,
-		Eval( 
-			ut test assertion decorator( 
-				ut test registered assertions[_utTestNS:iAssertion][1], 
-				ut test registered assertions[_utTestNS:iAssertion][2]
-			)
-		);
-	);
-	
-	_utTestNS:run setup expr = Expr(
-		// evaluate the setup expression
-		Try( 
-			Eval( _utTestNS:test case << Get Setup() );
-			Names Default to Here( 0 );
-			1;
-		,
-			Names Default to Here( 0 );
-			ut global reporter << Add Unexpected Throw( 
-				ut concat test label(
-					_utTestNS:test case << Get Test Case Name(),
-					_utTestNS:test name,
-					"Setup"
-				),
-				ut get exception expression( exception_msg ),
-				"test case setup does not throw...skipping test...",
-				::ut get exception message( exception_msg );
-			);
-			0;
-		);
-	);
-	
-	_utTestNS:run test expr = Expr(
-		// evaluate the test expression
-		Try( 
-			Eval( _utTestNS << Get Value("test expr") );
-			Names Default to Here( 0 );
-		,
-			Names Default to Here( 0 );
-			_utTestNS:temp label = ut concat test label(
-				_utTestNS:test case << Get Test Case Name(),
-				_utTestNS:test name,
-				"Test"
-			);
-			ut global reporter << Add Unexpected Throw( 
-				_utTestNS:temp label,
-				ut get exception expression( exception_msg ),
-				"test does not throw outside of an assertion",
-				::ut get exception message( exception_msg );
-			);
-		);
-	);
-	
-	_utTestNS:run teardown expr = Expr(
-		// evaluate the teardown expression
-		Try( 
-			Eval( _utTestNS:test case << Get Teardown() );
-			Names Default to Here( 0 );
-		,
-			Names Default to Here( 0 );
-			ut global reporter << Add Unexpected Throw( 
-				ut concat test label(
-					_utTestNS:test case << Get Test Case Name(),
-					_utTestNS:test name,
-					"Teardown"
-				),
-				ut get exception expression( exception_msg ),
-				"test case teardown does not throw",
-				::ut get exception message( exception_msg );
-			);
-		);
-	);
-	
-	// Get Do Log Bench() < 0 means don't capture
-	If( _utTestNS:log benchmark << Get Do Log Bench() >= 0,
-		// Replace reporter so event handlers don't happen under Log Capture
-		ut test buffering reporter:inner = ut global reporter;
-		ut global reporter = ut test buffering reporter;
-		
-		// Do Setup, Body, Teardown under Log Capture
-		_utTestNS:log = Log Capture( _utTestNS:setup success = Eval( _utTestNS << Get Value( "run setup expr" ) ) );
-		If( _utTestNS:setup success,
-			_utTestNS:log ||= Log Capture( Eval( _utTestNS << Get Value( "run test expr" ) ) );
-		);
-		_utTestNS:log ||= Log Capture( Eval( _utTestNS << Get Value( "run teardown expr" ) ) );
-		
-		// Release results to original reporter and restore it
-		ut global reporter = ut test buffering reporter << release();
-		
-		// Do benchmark if requested
-		If( _utTestNS:log benchmark << Get Do Log Bench(),
-			Local({log contents},
-				// Replace reporter so we supress success events
-				ut test filtering reporter:inner = ut global reporter;
-				ut global reporter = ut test filtering reporter;
-				
-				log contents = _utTestNS:log;
-				// Qualified so that the ut test log benchmark label
-				// is used without modification
-				_utTestNS:n asserts++;
-				Insert Into(_utTestNS:results,
-					::ut assert that(
-						Expr( log contents ), 
-						_utTestNS:log benchmark << Get Matcher(),
-						ut test log benchmark label(_utTestNS:test case:name, _utTestNS:test name)
-					);
-				);
-				
-				ut global reporter = ut test filtering reporter << release();
-			)
-		)
-	,
-		_utTestNS:setup success = Eval( _utTestNS << Get Value( "run setup expr" ) );
-		If( _utTestNS:setup success,
-			Eval( _utTestNS << Get Value("run test expr") );
-		);
-		Eval( _utTestNS << Get Value( "run teardown expr" ) );
-	);
-	
-	// get the symbols after the test case is run
-	_utTestNS:after symbols = ::ut get symbol information();
-	
-	// delete the symbols that were added during the test
-	::ut delete symbols difference( _utTestNS:before symbols, _utTestNS:after symbols, 1 /* Close Windows */ );
-	
-	// Return whether or not all asserts passed
-	First( All( _utTestNS:results ), Delete Namespaces( Force( 1 ), _utTestNS ) );
+ut define documented function(
+  "ut test",
+  Expr(Function({test case, test name, test expr, log benchmark = ut log bench()},
+    
+    // Validate inputs
+    If( 
+      Is String( Name Expr( test case ) ),
+        test case = ::ut test case( test case );
+    ,
+      !Is Class( Name Expr( test case ) ),
+        Throw( "ut test() requires the first argument to be a string or test case object." );
+    ,
+      test case << Get Name != "UtTestCaseFixture",
+        Throw( "ut test() requires the first argument to be a string or test case object." );
+    );
+    
+    If( !Is String( Name Expr( test name ) ),
+      Throw( "ut test() requires the second argument to be a string." );
+    );
+    
+    If( !Is Expr( Name Expr( test expr ) ),
+      Throw( "ut test() requires the third argument to be an expression." );
+    );
+    
+    If( !Is Class( Name Expr( log benchmark ) ),
+        Throw( "ut test() requires the optional fourth argument to be ut log bench( < 0 | 1 >, < string matcher > )" );
+    ,
+      log benchmark << Get Name != "UtLogBenchmark",
+        Throw( "ut test() requires the optional fourth argument to be ut log bench( < 0 | 1 >, < string matcher > )" );
+    );
+    
+    // Create an anonymous namespace that is not in the current
+    // dynamic scoping hierarchy.
+    // This variable is the only thing that could potentially collide 
+    // with a test.
+    local:_utTestNS = ut move to anonymous namespace( Namespace( "local" ) );
+    
+    // get the symbols defined before running the test case
+    _utTestNS:before symbols = ::ut get symbol information();
+    
+    _utTestNS:n asserts = 0;
+    _utTestNS:results = {};
+    
+    For( _utTestNS:iAssertion = 1, _utTestNS:iAssertion <= N Items( ut test registered assertions ), _utTestNS:iAssertion++,
+      Eval( 
+        ut test assertion decorator( 
+          ut test registered assertions[_utTestNS:iAssertion][1], 
+          ut test registered assertions[_utTestNS:iAssertion][2]
+        )
+      );
+    );
+    
+    _utTestNS:run setup expr = Expr(
+      // evaluate the setup expression
+      Try( 
+        Eval( _utTestNS:test case << Get Setup() );
+        Names Default to Here( 0 );
+        1;
+      ,
+        Names Default to Here( 0 );
+        ut global reporter << Add Unexpected Throw( 
+          ut concat test label(
+            _utTestNS:test case << Get Test Case Name(),
+            _utTestNS:test name,
+            "Setup"
+          ),
+          ut get exception expression( exception_msg ),
+          "test case setup does not throw...skipping test...",
+          ::ut get exception message( exception_msg );
+        );
+        0;
+      );
+    );
+    
+    _utTestNS:run test expr = Expr(
+      // evaluate the test expression
+      Try( 
+        Eval( _utTestNS << Get Value("test expr") );
+        Names Default to Here( 0 );
+      ,
+        Names Default to Here( 0 );
+        _utTestNS:temp label = ut concat test label(
+          _utTestNS:test case << Get Test Case Name(),
+          _utTestNS:test name,
+          "Test"
+        );
+        ut global reporter << Add Unexpected Throw( 
+          _utTestNS:temp label,
+          ut get exception expression( exception_msg ),
+          "test does not throw outside of an assertion",
+          ::ut get exception message( exception_msg );
+        );
+      );
+    );
+    
+    _utTestNS:run teardown expr = Expr(
+      // evaluate the teardown expression
+      Try( 
+        Eval( _utTestNS:test case << Get Teardown() );
+        Names Default to Here( 0 );
+      ,
+        Names Default to Here( 0 );
+        ut global reporter << Add Unexpected Throw( 
+          ut concat test label(
+            _utTestNS:test case << Get Test Case Name(),
+            _utTestNS:test name,
+            "Teardown"
+          ),
+          ut get exception expression( exception_msg ),
+          "test case teardown does not throw",
+          ::ut get exception message( exception_msg );
+        );
+      );
+    );
+    
+    // Get Do Log Bench() < 0 means don't capture
+    If( _utTestNS:log benchmark << Get Do Log Bench() >= 0,
+      // Replace reporter so event handlers don't happen under Log Capture
+      ut test buffering reporter:inner = ut global reporter;
+      ut global reporter = ut test buffering reporter;
+      
+      // Do Setup, Body, Teardown under Log Capture
+      _utTestNS:log = Log Capture( _utTestNS:setup success = Eval( _utTestNS << Get Value( "run setup expr" ) ) );
+      If( _utTestNS:setup success,
+        _utTestNS:log ||= Log Capture( Eval( _utTestNS << Get Value( "run test expr" ) ) );
+      );
+      _utTestNS:log ||= Log Capture( Eval( _utTestNS << Get Value( "run teardown expr" ) ) );
+      
+      // Release results to original reporter and restore it
+      ut global reporter = ut test buffering reporter << release();
+      
+      // Do benchmark if requested
+      If( _utTestNS:log benchmark << Get Do Log Bench(),
+        Local({log contents},
+          // Replace reporter so we supress success events
+          ut test filtering reporter:inner = ut global reporter;
+          ut global reporter = ut test filtering reporter;
+          
+          log contents = _utTestNS:log;
+          // Qualified so that the ut test log benchmark label
+          // is used without modification
+          _utTestNS:n asserts++;
+          Insert Into(_utTestNS:results,
+            ::ut assert that(
+              Expr( log contents ), 
+              _utTestNS:log benchmark << Get Matcher(),
+              ut test log benchmark label(_utTestNS:test case << Get Test Case Name, _utTestNS:test name)
+            );
+          );
+          
+          ut global reporter = ut test filtering reporter << release();
+        )
+      )
+    ,
+      _utTestNS:setup success = Eval( _utTestNS << Get Value( "run setup expr" ) );
+      If( _utTestNS:setup success,
+        Eval( _utTestNS << Get Value("run test expr") );
+      );
+      Eval( _utTestNS << Get Value( "run teardown expr" ) );
+    );
+    
+    // get the symbols after the test case is run
+    _utTestNS:after symbols = ::ut get symbol information();
+    
+    // delete the symbols that were added during the test
+    ::ut delete symbols difference( _utTestNS:before symbols, _utTestNS:after symbols, 1 /* Close Windows */ );
+    
+    // Return whether or not all asserts passed
+    First( All( _utTestNS:results ), Delete Namespaces( Force( 1 ), _utTestNS ) );
+  )),
+  "ut test( test case | test case name, test name, body, <log bench> )",
+  "Run a test expression. Runs any given setup and tear down expressions. Reports any unexpected exceptions as failures.\!n\!n" || 
+  "The log benchmark argument determines if the log is captured and whatis asserted about the captured log (if anything). The default is managed by the ut log bench and ut log bench default.",
+  {{
+    "Simple", 
+		"\[
+ut test( "TC #5", "addition",
+  Expr(
+    ut assert that( Expr( 5 + 6 ), 11 );
+    ut assert that( Expr( 5 + 5 ), 10, "my assert level comment" ); 
+  ),
+  ut log bench( 1, "" ) // Capture the log and assert that it is empty
 );
-
+]\"
+  }}
+);
 /*	Function: ut log bench
 		-------------Prototype-------------
 		ut log bench(

--- a/Source/Core/TestCase.jsl
+++ b/Source/Core/TestCase.jsl
@@ -148,56 +148,56 @@ Define Class(
 		---------------------------
 */
 ut define documented function(
-  "ut test case",
-  Expr(Function({name},
-    {obj},
-    obj = New Object( UtTestCaseFixture( name ) );
-    
-    // Set a reference to itself.
-    obj:self = local:obj;
-    
-    // return the object
-    obj
-  )),
-  "ut test case( test case name )",
-  "Used to isolate a test case from other code in the test file. Also prepends the name of the test and assert number to the beginning of the labels for ut assert that.",
-  {
-    {
-      "Setup/Teardown",
-      test case = ut test case( "Sample test case" )
-        << Setup( Expr( dt = Open( "$SAMPLE_DATA\Big Class.jmp" ); ) )
-        << Teardown( Expr( Close( dt, NoSave ); ) );
-        
-      ut test( test case, "test level comment",
-        Expr(
-          dt << new column( "Test", Formula( Row() ) );
-          ut assert that( Expr( dt:Test << Get Values ), (1::40)`, "my assert level comment" ); 
-        )
-      );
-      ut test( test case, "test level comment",
-        Expr(
-          dt << new column( "Test", Value Labels( {0 = "N", 1 = "Y"} ) );
-          ut assert that( Expr( dt:Test << Get Property( "Value Labels" ) ), Expr( Value Labels( {0 = "N", 1 = "Y"} ) ), "my assert level comment" );
-        )
-      );
-    },
-    {
-      "Repeating Labels",
-      test case = ut test case( "Sample test case" );
-      ut test( test case, "test level comment - addition",
-        Expr(
-          ut assert that( Expr( 5 + 6 ), 11 );
-          ut assert that( Expr( 5 + 5 ), 10, "my assert level comment" ); 
-        )
-      );
-      ut test( test case, "test level comment - subtraction",
-        Expr(
-          ut assert that( Expr( 5 - 6 ), -1 );
-          ut assert that( Expr( 5 - 5 ), 0, "my assert level comment" ); 
-        )
-      );
-    }
-  }
+	"ut test case",
+	Expr(Function({name},
+		{obj},
+		obj = New Object( UtTestCaseFixture( name ) );
+		
+		// Set a reference to itself.
+		obj:self = local:obj;
+		
+		// return the object
+		obj
+	)),
+	"ut test case( test case name )",
+	"Used to isolate a test case from other code in the test file. Also prepends the name of the test and assert number to the beginning of the labels for ut assert that.",
+	{
+		{
+			"Setup/Teardown",
+			test case = ut test case( "Sample test case" )
+				<< Setup( Expr( dt = Open( "$SAMPLE_DATA\Big Class.jmp" ); ) )
+				<< Teardown( Expr( Close( dt, NoSave ); ) );
+				
+			ut test( test case, "test level comment",
+				Expr(
+					dt << new column( "Test", Formula( Row() ) );
+					ut assert that( Expr( dt:Test << Get Values ), (1::40)`, "my assert level comment" ); 
+				)
+			);
+			ut test( test case, "test level comment",
+				Expr(
+					dt << new column( "Test", Value Labels( {0 = "N", 1 = "Y"} ) );
+					ut assert that( Expr( dt:Test << Get Property( "Value Labels" ) ), Expr( Value Labels( {0 = "N", 1 = "Y"} ) ), "my assert level comment" );
+				)
+			);
+		},
+		{
+			"Repeating Labels",
+			test case = ut test case( "Sample test case" );
+			ut test( test case, "test level comment - addition",
+				Expr(
+					ut assert that( Expr( 5 + 6 ), 11 );
+					ut assert that( Expr( 5 + 5 ), 10, "my assert level comment" ); 
+				)
+			);
+			ut test( test case, "test level comment - subtraction",
+				Expr(
+					ut assert that( Expr( 5 - 6 ), -1 );
+					ut assert that( Expr( 5 - 5 ), 0, "my assert level comment" ); 
+				)
+			);
+		}
+	}
 );
 
 /* 
@@ -364,190 +364,190 @@ ut test filtering reporter = New Object("UtSuccessFilteringReporter"(Empty()));
 		---------------------------
 */
 ut define documented function(
-  "ut test",
-  Expr(Function({test case, test name, test expr, log benchmark = ut log bench()},
-    
-    // Validate inputs
-    If( 
-      Is String( Name Expr( test case ) ),
-        test case = ::ut test case( test case );
-    ,
-      !Is Class( Name Expr( test case ) ),
-        Throw( "ut test() requires the first argument to be a string or test case object." );
-    ,
-      test case << Get Name != "UtTestCaseFixture",
-        Throw( "ut test() requires the first argument to be a string or test case object." );
-    );
-    
-    If( !Is String( Name Expr( test name ) ),
-      Throw( "ut test() requires the second argument to be a string." );
-    );
-    
-    If( !Is Expr( Name Expr( test expr ) ),
-      Throw( "ut test() requires the third argument to be an expression." );
-    );
-    
-    If( !Is Class( Name Expr( log benchmark ) ),
-        Throw( "ut test() requires the optional fourth argument to be ut log bench( < 0 | 1 >, < string matcher > )" );
-    ,
-      log benchmark << Get Name != "UtLogBenchmark",
-        Throw( "ut test() requires the optional fourth argument to be ut log bench( < 0 | 1 >, < string matcher > )" );
-    );
-    
-    // Create an anonymous namespace that is not in the current
-    // dynamic scoping hierarchy.
-    // This variable is the only thing that could potentially collide 
-    // with a test.
-    local:_utTestNS = ut move to anonymous namespace( Namespace( "local" ) );
-    
-    // get the symbols defined before running the test case
-    _utTestNS:before symbols = ::ut get symbol information();
-    
-    _utTestNS:n asserts = 0;
-    _utTestNS:results = {};
-    
-    For( _utTestNS:iAssertion = 1, _utTestNS:iAssertion <= N Items( ut test registered assertions ), _utTestNS:iAssertion++,
-      Eval( 
-        ut test assertion decorator( 
-          ut test registered assertions[_utTestNS:iAssertion][1], 
-          ut test registered assertions[_utTestNS:iAssertion][2]
-        )
-      );
-    );
-    
-    _utTestNS:run setup expr = Expr(
-      // evaluate the setup expression
-      Try( 
-        Eval( _utTestNS:test case << Get Setup() );
-        Names Default to Here( 0 );
-        1;
-      ,
-        Names Default to Here( 0 );
-        ut global reporter << Add Unexpected Throw( 
-          ut concat test label(
-            _utTestNS:test case << Get Test Case Name(),
-            _utTestNS:test name,
-            "Setup"
-          ),
-          ut get exception expression( exception_msg ),
-          "test case setup does not throw...skipping test...",
-          ::ut get exception message( exception_msg );
-        );
-        0;
-      );
-    );
-    
-    _utTestNS:run test expr = Expr(
-      // evaluate the test expression
-      Try( 
-        Eval( _utTestNS << Get Value("test expr") );
-        Names Default to Here( 0 );
-      ,
-        Names Default to Here( 0 );
-        _utTestNS:temp label = ut concat test label(
-          _utTestNS:test case << Get Test Case Name(),
-          _utTestNS:test name,
-          "Test"
-        );
-        ut global reporter << Add Unexpected Throw( 
-          _utTestNS:temp label,
-          ut get exception expression( exception_msg ),
-          "test does not throw outside of an assertion",
-          ::ut get exception message( exception_msg );
-        );
-      );
-    );
-    
-    _utTestNS:run teardown expr = Expr(
-      // evaluate the teardown expression
-      Try( 
-        Eval( _utTestNS:test case << Get Teardown() );
-        Names Default to Here( 0 );
-      ,
-        Names Default to Here( 0 );
-        ut global reporter << Add Unexpected Throw( 
-          ut concat test label(
-            _utTestNS:test case << Get Test Case Name(),
-            _utTestNS:test name,
-            "Teardown"
-          ),
-          ut get exception expression( exception_msg ),
-          "test case teardown does not throw",
-          ::ut get exception message( exception_msg );
-        );
-      );
-    );
-    
-    // Get Do Log Bench() < 0 means don't capture
-    If( _utTestNS:log benchmark << Get Do Log Bench() >= 0,
-      // Replace reporter so event handlers don't happen under Log Capture
-      ut test buffering reporter:inner = ut global reporter;
-      ut global reporter = ut test buffering reporter;
-      
-      // Do Setup, Body, Teardown under Log Capture
-      _utTestNS:log = Log Capture( _utTestNS:setup success = Eval( _utTestNS << Get Value( "run setup expr" ) ) );
-      If( _utTestNS:setup success,
-        _utTestNS:log ||= Log Capture( Eval( _utTestNS << Get Value( "run test expr" ) ) );
-      );
-      _utTestNS:log ||= Log Capture( Eval( _utTestNS << Get Value( "run teardown expr" ) ) );
-      
-      // Release results to original reporter and restore it
-      ut global reporter = ut test buffering reporter << release();
-      
-      // Do benchmark if requested
-      If( _utTestNS:log benchmark << Get Do Log Bench(),
-        Local({log contents},
-          // Replace reporter so we supress success events
-          ut test filtering reporter:inner = ut global reporter;
-          ut global reporter = ut test filtering reporter;
-          
-          log contents = _utTestNS:log;
-          // Qualified so that the ut test log benchmark label
-          // is used without modification
-          _utTestNS:n asserts++;
-          Insert Into(_utTestNS:results,
-            ::ut assert that(
-              Expr( log contents ), 
-              _utTestNS:log benchmark << Get Matcher(),
-              ut test log benchmark label(_utTestNS:test case << Get Test Case Name, _utTestNS:test name)
-            );
-          );
-          
-          ut global reporter = ut test filtering reporter << release();
-        )
-      )
-    ,
-      _utTestNS:setup success = Eval( _utTestNS << Get Value( "run setup expr" ) );
-      If( _utTestNS:setup success,
-        Eval( _utTestNS << Get Value("run test expr") );
-      );
-      Eval( _utTestNS << Get Value( "run teardown expr" ) );
-    );
-    
-    // get the symbols after the test case is run
-    _utTestNS:after symbols = ::ut get symbol information();
-    
-    // delete the symbols that were added during the test
-    ::ut delete symbols difference( _utTestNS:before symbols, _utTestNS:after symbols, 1 /* Close Windows */ );
-    
-    // Return whether or not all asserts passed
-    First( All( _utTestNS:results ), Delete Namespaces( Force( 1 ), _utTestNS ) );
-  )),
-  "ut test( test case | test case name, test name, body, <log bench> )",
-  "Run a test expression. Runs any given setup and tear down expressions. Reports any unexpected exceptions as failures.\!n\!n" || 
-  "The log benchmark argument determines if the log is captured and whatis asserted about the captured log (if anything). The default is managed by the ut log bench and ut log bench default.",
-  {{
-    "Simple", 
+	"ut test",
+	Expr(Function({test case, test name, test expr, log benchmark = ut log bench()},
+		
+		// Validate inputs
+		If( 
+			Is String( Name Expr( test case ) ),
+				test case = ::ut test case( test case );
+		,
+			!Is Class( Name Expr( test case ) ),
+				Throw( "ut test() requires the first argument to be a string or test case object." );
+		,
+			test case << Get Name != "UtTestCaseFixture",
+				Throw( "ut test() requires the first argument to be a string or test case object." );
+		);
+		
+		If( !Is String( Name Expr( test name ) ),
+			Throw( "ut test() requires the second argument to be a string." );
+		);
+		
+		If( !Is Expr( Name Expr( test expr ) ),
+			Throw( "ut test() requires the third argument to be an expression." );
+		);
+		
+		If( !Is Class( Name Expr( log benchmark ) ),
+				Throw( "ut test() requires the optional fourth argument to be ut log bench( < 0 | 1 >, < string matcher > )" );
+		,
+			log benchmark << Get Name != "UtLogBenchmark",
+				Throw( "ut test() requires the optional fourth argument to be ut log bench( < 0 | 1 >, < string matcher > )" );
+		);
+		
+		// Create an anonymous namespace that is not in the current
+		// dynamic scoping hierarchy.
+		// This variable is the only thing that could potentially collide 
+		// with a test.
+		local:_utTestNS = ut move to anonymous namespace( Namespace( "local" ) );
+		
+		// get the symbols defined before running the test case
+		_utTestNS:before symbols = ::ut get symbol information();
+		
+		_utTestNS:n asserts = 0;
+		_utTestNS:results = {};
+		
+		For( _utTestNS:iAssertion = 1, _utTestNS:iAssertion <= N Items( ut test registered assertions ), _utTestNS:iAssertion++,
+			Eval( 
+				ut test assertion decorator( 
+					ut test registered assertions[_utTestNS:iAssertion][1], 
+					ut test registered assertions[_utTestNS:iAssertion][2]
+				)
+			);
+		);
+		
+		_utTestNS:run setup expr = Expr(
+			// evaluate the setup expression
+			Try( 
+				Eval( _utTestNS:test case << Get Setup() );
+				Names Default to Here( 0 );
+				1;
+			,
+				Names Default to Here( 0 );
+				ut global reporter << Add Unexpected Throw( 
+					ut concat test label(
+						_utTestNS:test case << Get Test Case Name(),
+						_utTestNS:test name,
+						"Setup"
+					),
+					ut get exception expression( exception_msg ),
+					"test case setup does not throw...skipping test...",
+					::ut get exception message( exception_msg );
+				);
+				0;
+			);
+		);
+		
+		_utTestNS:run test expr = Expr(
+			// evaluate the test expression
+			Try( 
+				Eval( _utTestNS << Get Value("test expr") );
+				Names Default to Here( 0 );
+			,
+				Names Default to Here( 0 );
+				_utTestNS:temp label = ut concat test label(
+					_utTestNS:test case << Get Test Case Name(),
+					_utTestNS:test name,
+					"Test"
+				);
+				ut global reporter << Add Unexpected Throw( 
+					_utTestNS:temp label,
+					ut get exception expression( exception_msg ),
+					"test does not throw outside of an assertion",
+					::ut get exception message( exception_msg );
+				);
+			);
+		);
+		
+		_utTestNS:run teardown expr = Expr(
+			// evaluate the teardown expression
+			Try( 
+				Eval( _utTestNS:test case << Get Teardown() );
+				Names Default to Here( 0 );
+			,
+				Names Default to Here( 0 );
+				ut global reporter << Add Unexpected Throw( 
+					ut concat test label(
+						_utTestNS:test case << Get Test Case Name(),
+						_utTestNS:test name,
+						"Teardown"
+					),
+					ut get exception expression( exception_msg ),
+					"test case teardown does not throw",
+					::ut get exception message( exception_msg );
+				);
+			);
+		);
+		
+		// Get Do Log Bench() < 0 means don't capture
+		If( _utTestNS:log benchmark << Get Do Log Bench() >= 0,
+			// Replace reporter so event handlers don't happen under Log Capture
+			ut test buffering reporter:inner = ut global reporter;
+			ut global reporter = ut test buffering reporter;
+			
+			// Do Setup, Body, Teardown under Log Capture
+			_utTestNS:log = Log Capture( _utTestNS:setup success = Eval( _utTestNS << Get Value( "run setup expr" ) ) );
+			If( _utTestNS:setup success,
+				_utTestNS:log ||= Log Capture( Eval( _utTestNS << Get Value( "run test expr" ) ) );
+			);
+			_utTestNS:log ||= Log Capture( Eval( _utTestNS << Get Value( "run teardown expr" ) ) );
+			
+			// Release results to original reporter and restore it
+			ut global reporter = ut test buffering reporter << release();
+			
+			// Do benchmark if requested
+			If( _utTestNS:log benchmark << Get Do Log Bench(),
+				Local({log contents},
+					// Replace reporter so we supress success events
+					ut test filtering reporter:inner = ut global reporter;
+					ut global reporter = ut test filtering reporter;
+					
+					log contents = _utTestNS:log;
+					// Qualified so that the ut test log benchmark label
+					// is used without modification
+					_utTestNS:n asserts++;
+					Insert Into(_utTestNS:results,
+						::ut assert that(
+							Expr( log contents ), 
+							_utTestNS:log benchmark << Get Matcher(),
+							ut test log benchmark label(_utTestNS:test case << Get Test Case Name, _utTestNS:test name)
+						);
+					);
+					
+					ut global reporter = ut test filtering reporter << release();
+				)
+			)
+		,
+			_utTestNS:setup success = Eval( _utTestNS << Get Value( "run setup expr" ) );
+			If( _utTestNS:setup success,
+				Eval( _utTestNS << Get Value("run test expr") );
+			);
+			Eval( _utTestNS << Get Value( "run teardown expr" ) );
+		);
+		
+		// get the symbols after the test case is run
+		_utTestNS:after symbols = ::ut get symbol information();
+		
+		// delete the symbols that were added during the test
+		::ut delete symbols difference( _utTestNS:before symbols, _utTestNS:after symbols, 1 /* Close Windows */ );
+		
+		// Return whether or not all asserts passed
+		First( All( _utTestNS:results ), Delete Namespaces( Force( 1 ), _utTestNS ) );
+	)),
+	"ut test( test case | test case name, test name, body, <log bench> )",
+	"Run a test expression. Runs any given setup and tear down expressions. Reports any unexpected exceptions as failures.\!n\!n" || 
+	"The log benchmark argument determines if the log is captured and whatis asserted about the captured log (if anything). The default is managed by the ut log bench and ut log bench default.",
+	{{
+		"Simple", 
 		"\[
 ut test( "TC #5", "addition",
-  Expr(
-    ut assert that( Expr( 5 + 6 ), 11 );
-    ut assert that( Expr( 5 + 5 ), 10, "my assert level comment" ); 
-  ),
-  ut log bench( 1, "" ) // Capture the log and assert that it is empty
+	Expr(
+		ut assert that( Expr( 5 + 6 ), 11 );
+		ut assert that( Expr( 5 + 5 ), 10, "my assert level comment" ); 
+	),
+	ut log bench( 1, "" ) // Capture the log and assert that it is empty
 );
 ]\"
-  }}
+	}}
 );
 /*	Function: ut log bench
 		-------------Prototype-------------
@@ -562,7 +562,7 @@ ut test( "TC #5", "addition",
 		-  1: Capture the log and assert that contents satisfy the matcher
 		- -1: Do not capture the log (no benchmark, matcher not run)
 
-   		Factory function for <UtLogBenchmark>
+	 		Factory function for <UtLogBenchmark>
 
 	Arguments:
 		do_log_bench - See description above.

--- a/Source/Core/TestCase.jsl
+++ b/Source/Core/TestCase.jsl
@@ -535,7 +535,7 @@ ut define documented function(
 	)),
 	"ut test( test case | test case name, test name, body, <log bench> )",
 	"Run a test expression. Runs any given setup and tear down expressions. Reports any unexpected exceptions as failures.\!n\!n" || 
-	"The log benchmark argument determines if the log is captured and whatis asserted about the captured log (if anything). The default is managed by the ut log bench and ut log bench default.",
+	"The log benchmark argument determines if the log is captured and what is asserted about the captured log (if anything). The default is managed by the ut log bench and ut log bench default.",
 	{{
 		"Simple", 
 		"\[

--- a/Source/Core/Utils.jsl
+++ b/Source/Core/Utils.jsl
@@ -35,7 +35,7 @@ ut matcher factory = Function( {name, function decl=Empty(), prototype="", descr
 	If( !Contains( ut matcher factories, As Name( name ) ),
 		Insert Into( ut matcher factories, As Name( name ) );
 	);
-	If( !Is Empty( Name Expr( funciton decl ) ),
+	If( !Is Empty( Name Expr( function decl ) ),
 		ut define documented function( name, Name Expr( function decl ), prototype, description, examples );
 	);
 	ut nullptr;

--- a/Source/Core/Utils.jsl
+++ b/Source/Core/Utils.jsl
@@ -39,7 +39,6 @@ ut deploy documented functions = Function({},
 		name - string name for the function
 */
 ut matcher factory = Function( {name, function decl=Empty(), prototype="", description="", examples={}}, 
-	{global name, i},
 
 	If( !Contains( ut matcher factories, As Name( name ) ),
 		Insert Into( ut matcher factories, As Name( name ) );
@@ -54,6 +53,7 @@ ut matcher factory = Function( {name, function decl=Empty(), prototype="", descr
 		Define a documented function in the Scripting Index
 */
 ut define documented function = Function({name, function decl, prototype, description, examples},
+	{cf, i},
 	// add a copy of the function to the package namespace and scripting index.
 	If( ut should deploy documented functions,
 		cf = New Custom Function( "global", name, function decl,
@@ -62,6 +62,9 @@ ut define documented function = Function({name, function decl, prototype, descri
 			<< Description( description )
 		);
 		For( i = 1, i <= N Items( examples ), i++,
+			If( N Items( examples[i] ) != 2,
+				Throw("Examples must contain a name and script."),
+			);
 			// A string can be used for an example to preserve
 			// whitespace and comments.
 			If( Is String( examples[i][2] ),

--- a/Source/Core/Utils.jsl
+++ b/Source/Core/Utils.jsl
@@ -11,8 +11,9 @@ Names Default To Here( 0 );
 ut matcher factories = {};
 
 // Variable: ut add custom functions
+// Only overwritten if not already set. Default is 1.
 If( Is Empty( ut add custom functions ), 
-  ut add custom functions = 1;
+	ut add custom functions = 1;
 );
 
 // Variable: ut custom functions
@@ -28,42 +29,42 @@ ut custom functions = {};
 	Arguments:
 		name - string name for the function
 */
-ut matcher factory = Function( {name, function decl=Expr(Function({}, .)), prototype="", description="", examples={}}, 
+ut matcher factory = Function( {name, function decl=Empty(), prototype="", description="", examples={}}, 
 	{global name, i},
 
-  If( !Contains( ut matcher factories, As Name( name ) ),
+	If( !Contains( ut matcher factories, As Name( name ) ),
 		Insert Into( ut matcher factories, As Name( name ) );
-  );
-  
-  ut define documented function( name, Name Expr( function decl ), prototype, description, examples );
-  
-  ut nullptr;
+	);
+	If( !Is Empty( Name Expr( funciton decl ) ),
+		ut define documented function( name, Name Expr( function decl ), prototype, description, examples );
+	);
+	ut nullptr;
 );
 
 /*  Function: ut define custom function
-      Define a documented function in the Scripting Index
+		Define a documented function in the Scripting Index
 */
 ut define documented function = Function({name, function decl, prototype, description, examples},
-  // add a copy of the function to the package namespace and scripting index.
-  If( ut add custom functions,
-    cf = New Custom Function( "global", name, function decl,
-      << Scripting Index Category( ut package name ),
-      << Prototype( prototype ),
-      << Description( description )
-    );
-    For( i = 1, i <= N Items( examples ), i++,
-      // A string can be used for an example to preserve
-      // whitespace and comments.
-      If( Is String( examples[i][2] ),
-        cf << Example( "Names Default To Here( 0 );\!nut global reporter = ut streaming log reporter();\!n" || examples[i][2], examples[i][1] );
-      ,
-        cf << Example( ut merge expressions( Eval List( {Expr(Names Default To Here( 0 ); ut global reporter = ut streaming log reporter(); ), examples[i][2]} ) ), examples[i][1] );
-      );
-    );
-    Insert Into( ut custom functions, cf );
-  ,
-    // Just assign the ut global function if not using custom functions
-    As Scoped( "global", name || "" ) = function decl;
+	// add a copy of the function to the package namespace and scripting index.
+	If( ut add custom functions,
+		cf = New Custom Function( "global", name, function decl,
+			<< Scripting Index Category( ut package name ),
+			<< Prototype( prototype ),
+			<< Description( description )
+		);
+		For( i = 1, i <= N Items( examples ), i++,
+			// A string can be used for an example to preserve
+			// whitespace and comments.
+			If( Is String( examples[i][2] ),
+				cf << Example( "Names Default To Here( 0 );\!nut global reporter = ut streaming log reporter();\!n" || examples[i][2], examples[i][1] );
+			,
+				cf << Example( ut merge expressions( Eval List( {Expr(Names Default To Here( 0 ); ut global reporter = ut streaming log reporter(); ), examples[i][2]} ) ), examples[i][1] );
+			);
+		);
+		Insert Into( ut custom functions, cf );
+	,
+	// Just assign the ut global function if not using custom functions
+		As Scoped( "global", name || "" ) = function decl;
 	);
 );
 
@@ -172,7 +173,6 @@ ut unregister matcher factory = Function( {name},
 	pos = Contains( ut matcher factories, As Name( name ) );
 	If( pos,
 		Remove From( ut matcher factories, pos );
-    Remove Custom Functions( "::" || name );
 	);
 );
 

--- a/Source/Core/Utils.jsl
+++ b/Source/Core/Utils.jsl
@@ -134,7 +134,7 @@ ut ensure matcher list = Function({matchers},
  		behavior is to always return missing (LRE unsupported).
 
  		<ut global lre> is used by the Equal To and Close To matchers
-   		to report the LRE value based on actual and expected values.
+	 	to report the LRE value based on actual and expected values.
 */
 ut global lre = Function( {actual, expected},
 	{i = 1, compute lre},
@@ -184,17 +184,17 @@ ut unregister matcher factory = Function( {name},
 		expression threw an error.
 */
 ut with reporter = Function({reporter, expression},
-    {global reporter},
-    global reporter = ut global reporter;
-    ut global reporter = reporter;
-    Try(
-        First(
-            expression,
-            ut global reporter = global reporter
-        ),
-        ut global reporter = global reporter;
-        Throw( Char( exception_msg ) );
-    );
+	{global reporter},
+	global reporter = ut global reporter;
+	ut global reporter = reporter;
+	Try(
+		First(
+			expression,
+			ut global reporter = global reporter
+		),
+		ut global reporter = global reporter;
+		Throw( Char( exception_msg ) );
+	);
 );
 
 /*
@@ -397,10 +397,10 @@ ut equal with missing = Function( {a, b},
 
 /*
 	Function: ut get show string
-	   Converts non-string values to character. 
-	   If the value is a string, double quotes are concatenated 
-	   to the beginning and end. This is used for showing values
-	   in expected and actual results.
+		Converts non-string values to character. 
+		If the value is a string, double quotes are concatenated 
+		to the beginning and end. This is used for showing values
+		in expected and actual results.
 */
 ut get show string = Function( {obj},
 	If( Is String( Name Expr( obj ) ),
@@ -509,7 +509,7 @@ ut expr literal = Function( {an expr},
 ut concat test label sep = "⮚";
 
 /*	Function: ut concat test label
-   		Concatenates values together for <ut test>
+	 		Concatenates values together for <ut test>
 */
 ut concat test label = Function({test case name, test name, label="", n asserts=.},
 	{labelList},
@@ -672,9 +672,9 @@ ut include jsl files recursively = Function( {folder},
 			Insert Into( include exprs, Eval Expr( Include( Expr( folder || "/" || files[iFile] ) ) ) );
 		);
 	);
-    // Eval after loop to avoid name collisions 
-    // with files and iFile.
-    Eval List( include exprs );
+	// Eval after loop to avoid name collisions 
+	// with files and iFile.
+	Eval List( include exprs );
 );
 
 // Variable: ut nullptr

--- a/Source/Core/Utils.jsl
+++ b/Source/Core/Utils.jsl
@@ -10,9 +10,14 @@ Names Default To Here( 0 );
 */
 ut matcher factories = {};
 
+// Variable: ut add custom functions
+If( Is Empty( ut add custom functions ), 
+  ut add custom functions = 1;
+);
+
 /*	Function: ut matcher factory
 		---Prototype---
-		ut matcher factory( string name )
+		ut matcher factory( String name, Function func, String prototype = "", String description = "", List<List> examples )
 		---------------
 		Function used to insert their names into the ut matcher 
 		factories list.
@@ -20,9 +25,42 @@ ut matcher factories = {};
 	Arguments:
 		name - string name for the function
 */
-ut matcher factory = Function({name},
-	If( !Contains( ut matcher factories, As Name( name ) ),
+ut matcher factory = Function( {name, function decl=Expr(Function({}, .)), prototype="", description="", examples={}}, 
+	{global name, i},
+
+  If( !Contains( ut matcher factories, As Name( name ) ),
 		Insert Into( ut matcher factories, As Name( name ) );
+  );
+  
+  ut define documented function( name, Name Expr( function decl ), prototype, description, examples );
+  
+  ut nullptr;
+);
+
+/*  Function: ut define custom function
+      Define a documented function in the Scripting Index
+*/
+ut define documented function = Function({name, function decl, prototype, description, examples},
+  // add a copy of the function to the package namespace and scripting index.
+  If( ut add custom functions,
+    cf = New Custom Function( "global", name, function decl,
+      << Scripting Index Category( ut package name ),
+      << Prototype( prototype ),
+      << Description( description )
+    );
+    For( i = 1, i <= N Items( examples ), i++,
+      // A string can be used for an example to preserve
+      // whitespace and comments.
+      If( Is String( examples[i][2] ),
+        cf << Example( "Names Default To Here( 0 );\!nut global reporter = ut streaming log reporter();\!n" || examples[i][2], examples[i][1] );
+      ,
+        cf << Example( ut merge expressions( Eval List( {Expr(Names Default To Here( 0 ); ut global reporter = ut streaming log reporter(); ), examples[i][2]} ) ), examples[i][1] );
+      );
+    );
+    Log Capture( Add Custom Functions( {cf} ) );
+  ,
+    // Just assign the ut global function if not using custom functions
+    As Scoped( "global", name || "" ) = function decl;
 	);
 );
 
@@ -131,6 +169,7 @@ ut unregister matcher factory = Function( {name},
 	pos = Contains( ut matcher factories, As Name( name ) );
 	If( pos,
 		Remove From( ut matcher factories, pos );
+    Remove Custom Functions( "::" || name );
 	);
 );
 

--- a/Source/Core/Utils.jsl
+++ b/Source/Core/Utils.jsl
@@ -15,6 +15,9 @@ If( Is Empty( ut add custom functions ),
   ut add custom functions = 1;
 );
 
+// Variable: ut custom functions
+ut custom functions = {};
+
 /*	Function: ut matcher factory
 		---Prototype---
 		ut matcher factory( String name, Function func, String prototype = "", String description = "", List<List> examples )
@@ -57,7 +60,7 @@ ut define documented function = Function({name, function decl, prototype, descri
         cf << Example( ut merge expressions( Eval List( {Expr(Names Default To Here( 0 ); ut global reporter = ut streaming log reporter(); ), examples[i][2]} ) ), examples[i][1] );
       );
     );
-    Log Capture( Add Custom Functions( {cf} ) );
+    Insert Into( ut custom functions, cf );
   ,
     // Just assign the ut global function if not using custom functions
     As Scoped( "global", name || "" ) = function decl;

--- a/Source/Core/Utils.jsl
+++ b/Source/Core/Utils.jsl
@@ -10,14 +10,23 @@ Names Default To Here( 0 );
 */
 ut matcher factories = {};
 
-// Variable: ut add custom functions
+// Variable: ut documented functions
+ut documented functions = {};
+
+// Variable: ut should deploy documented functions
 // Only overwritten if not already set. Default is 1.
-If( Is Empty( ut add custom functions ), 
-	ut add custom functions = 1;
+If( Is Empty( ut should deploy documented functions ), 
+	ut should deploy documented functions = 1;
 );
 
-// Variable: ut custom functions
-ut custom functions = {};
+ut deploy documented functions = Function({},
+	If( ut should deploy documented functions,
+		Log Capture( Add Custom Functions( ut documented functions ) );
+		// Clear memory and make room to call again with new fuctions
+		ut documented functions = {};
+	);
+	ut nullptr;
+);
 
 /*	Function: ut matcher factory
 		---Prototype---
@@ -46,7 +55,7 @@ ut matcher factory = Function( {name, function decl=Empty(), prototype="", descr
 */
 ut define documented function = Function({name, function decl, prototype, description, examples},
 	// add a copy of the function to the package namespace and scripting index.
-	If( ut add custom functions,
+	If( ut should deploy documented functions,
 		cf = New Custom Function( "global", name, function decl,
 			<< Scripting Index Category( ut package name ),
 			<< Prototype( prototype ),
@@ -61,11 +70,10 @@ ut define documented function = Function({name, function decl, prototype, descri
 				cf << Example( ut merge expressions( Eval List( {Expr(Names Default To Here( 0 ); ut global reporter = ut streaming log reporter(); ), examples[i][2]} ) ), examples[i][1] );
 			);
 		);
-		Insert Into( ut custom functions, cf );
-	,
-	// Just assign the ut global function if not using custom functions
-		As Scoped( "global", name || "" ) = function decl;
+		Insert Into( ut documented functions, cf );
 	);
+	// Always assign the ut global function, for backwards compatibility
+	As Scoped( "global", name || "" ) = function decl;
 );
 
 /*	Function: ut is a matcher

--- a/Source/Matchers/AllOf.jsl
+++ b/Source/Matchers/AllOf.jsl
@@ -1,4 +1,4 @@
-// Copyright © 2019, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
+﻿// Copyright © 2019, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 Names Default To Here( 0 );
@@ -56,7 +56,23 @@ Define Class(
 	Note:
 		This matcher will give the test expression (unevaluated) to each matcher in the given list.
 */
-ut matcher factory( "ut all of" );
-ut all of = Function( {matchers},
-	New Object( UtAllOfMatcher( ut ensure matcher list( matchers ) ) );
+	
+ut matcher factory(
+  // Function name
+	"ut all of", 
+  // Function declaration
+	Expr(Function( {matchers},
+		New Object( UtAllOfMatcher( ut ensure matcher list( matchers ) ) );
+	)),
+  // Prototype
+	"ut all of( matchers )", 
+  // Description
+	"Matches the test expression with every matcher given in the list.\!n\!nThis matcher will give the test expression (unevaluated) to each matcher in the given list.", 
+	// Examples
+  { 
+    {
+      "Simple", 
+      ut assert that( Expr( 5 + 5 ), ut all of( { ut equal to( 10 ), ut typed as( "Number" ) } ) );
+    }
+  }
 );

--- a/Source/Matchers/AllOf.jsl
+++ b/Source/Matchers/AllOf.jsl
@@ -58,21 +58,21 @@ Define Class(
 */
 	
 ut matcher factory(
-  // Function name
+	// Function name
 	"ut all of", 
-  // Function declaration
+	// Function declaration
 	Expr(Function( {matchers},
 		New Object( UtAllOfMatcher( ut ensure matcher list( matchers ) ) );
 	)),
-  // Prototype
+	// Prototype
 	"ut all of( matchers )", 
-  // Description
+	// Description
 	"Matches the test expression with every matcher given in the list.\!n\!nThis matcher will give the test expression (unevaluated) to each matcher in the given list.", 
 	// Examples
-  { 
-    {
-      "Simple", 
-      ut assert that( Expr( 5 + 5 ), ut all of( { ut equal to( 10 ), ut typed as( "Number" ) } ) );
-    }
-  }
+	{ 
+		{
+			"Simple", 
+			ut assert that( Expr( 5 + 5 ), ut all of( { ut equal to( 10 ), ut typed as( "Number" ) } ) );
+		}
+	}
 );

--- a/Source/Matchers/AnyOf.jsl
+++ b/Source/Matchers/AnyOf.jsl
@@ -57,11 +57,11 @@ Define Class(
 		This matcher will give the test expression (unevaluated) to each matcher in the given list.
 */
 ut matcher factory( 
-  "ut any of",
-  Expr(Function( {matchers},
-    New Object( UtAnyOfMatcher( ut ensure matcher list( matchers ) ) );
-  )),
-  "ut any of( matchers )",
-  "Matches the test expression with any matcher given in the list.\!n\!nThis matcher will give the test expression (unevaluated) to each matcher in the given list.",
-  {{"Simple", ut assert that( Expr( 5 + 5 ), ut any of( {19, 10} ) ); }}
+	"ut any of",
+	Expr(Function( {matchers},
+		New Object( UtAnyOfMatcher( ut ensure matcher list( matchers ) ) );
+	)),
+	"ut any of( matchers )",
+	"Matches the test expression with any matcher given in the list.\!n\!nThis matcher will give the test expression (unevaluated) to each matcher in the given list.",
+	{{"Simple", ut assert that( Expr( 5 + 5 ), ut any of( {19, 10} ) ); }}
 );

--- a/Source/Matchers/AnyOf.jsl
+++ b/Source/Matchers/AnyOf.jsl
@@ -56,7 +56,12 @@ Define Class(
 	Note:
 		This matcher will give the test expression (unevaluated) to each matcher in the given list.
 */
-ut matcher factory( "ut any of" );
-ut any of = Function( {matchers},
-	New Object( UtAnyOfMatcher( ut ensure matcher list( matchers ) ) );
+ut matcher factory( 
+  "ut any of",
+  Expr(Function( {matchers},
+    New Object( UtAnyOfMatcher( ut ensure matcher list( matchers ) ) );
+  )),
+  "ut any of( matchers )",
+  "Matches the test expression with any matcher given in the list.\!n\!nThis matcher will give the test expression (unevaluated) to each matcher in the given list.",
+  {{"Simple", ut assert that( Expr( 5 + 5 ), ut any of( {19, 10} ) ); }}
 );

--- a/Source/Matchers/Anything.jsl
+++ b/Source/Matchers/Anything.jsl
@@ -34,12 +34,12 @@ Define Class(
 		> ut assert that( Expr( Sin( "a" ), ut throws( ut anything() ) ) );
 */
 ut matcher factory( "ut anything",
-  Expr(Function( {},
-    New Object( UtAnythingMatcher() )
-  )),
-  "ut anything()",
-  "Always returns a success.",
-  {{"Simple", ut assert that( Expr( 5 + 5 ), ut anything() ); ut assert that( Expr( Sin( "a" ), ut throws( ut anything() ) ) );}}
+	Expr(Function( {},
+		New Object( UtAnythingMatcher() )
+	)),
+	"ut anything()",
+	"Always returns a success.",
+	{{"Simple", ut assert that( Expr( 5 + 5 ), ut anything() ); ut assert that( Expr( Sin( "a" ), ut throws( ut anything() ) ) );}}
 );
 
 /*
@@ -50,10 +50,10 @@ ut matcher factory( "ut anything",
 		Alias of <ut anything>.
 */
 ut matcher factory( "ut wild", 
-  Expr(Function( {},
-    New Object( UtAnythingMatcher() )
-  )),
-  "ut wild()",
-  "Alias of ut anything. Always returns a success.",
-  {{"Simple", ut assert that( Expr( 5 + 5 ), ut wild() ); ut assert that( Expr( Sin( "a" ), ut throws( ut wild() ) ) );}}
+	Expr(Function( {},
+		New Object( UtAnythingMatcher() )
+	)),
+	"ut wild()",
+	"Alias of ut anything. Always returns a success.",
+	{{"Simple", ut assert that( Expr( 5 + 5 ), ut wild() ); ut assert that( Expr( Sin( "a" ), ut throws( ut wild() ) ) );}}
 );

--- a/Source/Matchers/Anything.jsl
+++ b/Source/Matchers/Anything.jsl
@@ -39,7 +39,7 @@ ut matcher factory( "ut anything",
 	)),
 	"ut anything()",
 	"Always returns a success.",
-	{{"Simple", ut assert that( Expr( 5 + 5 ), ut anything() ); ut assert that( Expr( Sin( "a" ), ut throws( ut anything() ) ) );}}
+	{{"Simple", ut assert that( Expr( 5 + 5 ), ut anything() ); ut assert that( Expr( Sin( "a" ) ), ut throws( ut anything() ) );}}
 );
 
 /*
@@ -55,5 +55,5 @@ ut matcher factory( "ut wild",
 	)),
 	"ut wild()",
 	"Alias of ut anything. Always returns a success.",
-	{{"Simple", ut assert that( Expr( 5 + 5 ), ut wild() ); ut assert that( Expr( Sin( "a" ), ut throws( ut wild() ) ) );}}
+	{{"Simple", ut assert that( Expr( 5 + 5 ), ut wild() ); ut assert that( Expr( Sin( "a" ) ), ut throws( ut wild() ) );}}
 );

--- a/Source/Matchers/Anything.jsl
+++ b/Source/Matchers/Anything.jsl
@@ -33,9 +33,13 @@ Define Class(
 		> ut assert that( Expr( 5 + 5 ), ut anything() );
 		> ut assert that( Expr( Sin( "a" ), ut throws( ut anything() ) ) );
 */
-ut matcher factory( "ut anything" );
-ut anything = Function( {},
-	New Object( UtAnythingMatcher() )
+ut matcher factory( "ut anything",
+  Expr(Function( {},
+    New Object( UtAnythingMatcher() )
+  )),
+  "ut anything()",
+  "Always returns a success.",
+  {{"Simple", ut assert that( Expr( 5 + 5 ), ut anything() ); ut assert that( Expr( Sin( "a" ), ut throws( ut anything() ) ) );}}
 );
 
 /*
@@ -45,5 +49,11 @@ ut anything = Function( {},
 		---------------
 		Alias of <ut anything>.
 */
-ut matcher factory( "ut wild" );
-ut wild = Name Expr( ut anything );
+ut matcher factory( "ut wild", 
+  Expr(Function( {},
+    New Object( UtAnythingMatcher() )
+  )),
+  "ut wild()",
+  "Alias of ut anything. Always returns a success.",
+  {{"Simple", ut assert that( Expr( 5 + 5 ), ut wild() ); ut assert that( Expr( Sin( "a" ), ut throws( ut wild() ) ) );}}
+);

--- a/Source/Matchers/Approx.jsl
+++ b/Source/Matchers/Approx.jsl
@@ -193,26 +193,35 @@ Define Class(
 		ut assert that( Expr( 0 + 0 ), ut approx( 0.1, {Zero Epsilon( .2 )} ) );
 		---------
 */
-ut matcher factory( "ut approx" );
-ut approx = Function( {val, options={Zero Epsilon( 1e-12 ), Relative Epsilon( 1e-9 )}},
-	{ze, re},
-	If( 
-		!Is Number( Name Expr( val ) ) & !Is Matrix( Name Expr( val ) ),
-			Throw("First argument for ut approx() must be a number or matrix." );
-	,
-		!Is List( options ), 
-			Throw("Second argument for ut approx() must be a list." );
-	);
-	ze = Try( options["Zero Epsilon"], 1e-12 );
-	re = Try( options["Relative Epsilon"], 1e-9 );
-	
-	If( Is Matrix( val ) & Is Matrix( re ),
-		If( !(N Col( val ) == N Col( re ) & N Row( val ) == N Row( re ) ),
-			Throw( "When the expected value and Relative Epsilon are both matrices, they must be the same size." )
-		);
-	);
-	
-	New Object( UtApproxMatcher( val, ze, re ) );
+ut matcher factory( "ut approx",
+  Expr(Function( {val, options={Zero Epsilon( 1e-12 ), Relative Epsilon( 1e-9 )}},
+    {ze, re},
+    If( 
+      !Is Number( Name Expr( val ) ) & !Is Matrix( Name Expr( val ) ),
+        Throw("First argument for ut approx() must be a number or matrix." );
+    ,
+      !Is List( options ), 
+        Throw("Second argument for ut approx() must be a list." );
+    );
+    ze = Try( options["Zero Epsilon"], 1e-12 );
+    re = Try( options["Relative Epsilon"], 1e-9 );
+    
+    If( Is Matrix( val ) & Is Matrix( re ),
+      If( !(N Col( val ) == N Col( re ) & N Row( val ) == N Row( re ) ),
+        Throw( "When the expected value and Relative Epsilon are both matrices, they must be the same size." )
+      );
+    );
+    
+    New Object( UtApproxMatcher( val, ze, re ) );
+  )),
+  "ut approx( value, <options> )",
+  "Returns a success if the relative difference between expected and actual is within the relative epsilon for non-zero values and within zero epsilon if the expected or actual value is 0. Works only on numbers and matrices.",
+  {{
+    "Simple",
+    ut assert that( Expr( 5 + 5 ), ut approx( 10.000000001 ) );
+    ut assert that( Expr( 5 + 5 ), ut approx( 10.0001, {Relative Epsilon( 1e-5 )} ) );
+    ut assert that( Expr( 0 + 0 ), ut approx( 0.1, {Zero Epsilon( .2 )} ) );
+  }}
 );
 
 /* 
@@ -238,18 +247,27 @@ ut approx = Function( {val, options={Zero Epsilon( 1e-12 ), Relative Epsilon( 1e
 		ut assert that( expr( [5] + [5] ), ut approx digits( [10.1], [2] ) )
 		---------
 */
-ut matcher factory( "ut approx digits" );
-ut approx digits = Function({val, digits},
-	
-	If( 
-		!Is Number( Name Expr( val ) ) & !Is Matrix( Name Expr( val ) ), 
-			Throw("First argument for ut approx digits() must be a number or matrix." );
-	,
-		!Is Number( Name Expr( digits ) ) & !Is Matrix( Name Expr( digits ) ),
-			Throw("Second argument for ut approx digits() must be a matrix or number of digits." )
-	);
-	
-	New Object( UtApproxDigitsMatcher( val, digits ) );
+ut matcher factory( "ut approx digits",
+  Expr(Function({val, digits},
+    
+    If( 
+      !Is Number( Name Expr( val ) ) & !Is Matrix( Name Expr( val ) ), 
+        Throw("First argument for ut approx digits() must be a number or matrix." );
+    ,
+      !Is Number( Name Expr( digits ) ) & !Is Matrix( Name Expr( digits ) ),
+        Throw("Second argument for ut approx digits() must be a matrix or number of digits." )
+    );
+    
+    New Object( UtApproxDigitsMatcher( val, digits ) );
+  )),
+  "ut approx digits( value, digits )",
+  "Returns a success if the actual value matches the expected value up to N digits. Works only on numbers and matrices.",
+  {{
+    "Simple",
+    ut assert that( Expr( 5 + 5 ), ut approx digits( 10.001, 4 ) );
+		ut assert that( Expr( 0 + 0 ), ut approx digits( 0.1, 1 ) );
+		ut assert that( expr( [5] + [5] ), ut approx digits( [10.1], [2] ) )
+  }}
 );
 
 /* 
@@ -257,7 +275,8 @@ ut approx digits = Function({val, digits},
 		---Prototype---
 		ut min lre( number val, number minLRE )
 		---------------
-		Returns a success if 
+		Returns a success if LRE of actual value and expected value is above
+    a given threshold.
 		
 		Works only on numbers and matrices.
 		
@@ -272,14 +291,18 @@ ut approx digits = Function({val, digits},
 		ut assert that( Expr( 5 + 5 ), ut min lre( 10.1, 2 ) );
 		---------
 */
-ut matcher factory( "ut min lre" );
-ut min lre = Function({val, mLRE},
-	If( 
-		!Is Number( Name Expr( val ) ) & !Is Matrix( Name Expr( val ) ),
-			Throw("First argument for ut min lre() must be a number or matrix." );
-	,
-		!Is Number( Name Expr( mLRE ) ) & !Is Matrix( Name Expr( mLRE ) ),
-			Throw("Second argument for ut min lre() must be a number or matrix." );
-	);
-	New Object( UtMinLREMatcher( val, mLRE ) )
+ut matcher factory( "ut min lre",
+  Expr(Function({val, mLRE},
+    If( 
+      !Is Number( Name Expr( val ) ) & !Is Matrix( Name Expr( val ) ),
+        Throw("First argument for ut min lre() must be a number or matrix." );
+    ,
+      !Is Number( Name Expr( mLRE ) ) & !Is Matrix( Name Expr( mLRE ) ),
+        Throw("Second argument for ut min lre() must be a number or matrix." );
+    );
+    New Object( UtMinLREMatcher( val, mLRE ) )
+  )),
+  "ut min lre( value, minLRE )",
+  "Returns a success if LRE of actual value and expected value is above a given threshold. Works only on numbers and matrices.",
+  {{"Simple", ut assert that( Expr( 5 + 5 ), ut min lre( 10.1, 2 ) );}}
 );

--- a/Source/Matchers/Approx.jsl
+++ b/Source/Matchers/Approx.jsl
@@ -194,34 +194,34 @@ Define Class(
 		---------
 */
 ut matcher factory( "ut approx",
-  Expr(Function( {val, options={Zero Epsilon( 1e-12 ), Relative Epsilon( 1e-9 )}},
-    {ze, re},
-    If( 
-      !Is Number( Name Expr( val ) ) & !Is Matrix( Name Expr( val ) ),
-        Throw("First argument for ut approx() must be a number or matrix." );
-    ,
-      !Is List( options ), 
-        Throw("Second argument for ut approx() must be a list." );
-    );
-    ze = Try( options["Zero Epsilon"], 1e-12 );
-    re = Try( options["Relative Epsilon"], 1e-9 );
-    
-    If( Is Matrix( val ) & Is Matrix( re ),
-      If( !(N Col( val ) == N Col( re ) & N Row( val ) == N Row( re ) ),
-        Throw( "When the expected value and Relative Epsilon are both matrices, they must be the same size." )
-      );
-    );
-    
-    New Object( UtApproxMatcher( val, ze, re ) );
-  )),
-  "ut approx( value, <options> )",
-  "Returns a success if the relative difference between expected and actual is within the relative epsilon for non-zero values and within zero epsilon if the expected or actual value is 0. Works only on numbers and matrices.",
-  {{
-    "Simple",
-    ut assert that( Expr( 5 + 5 ), ut approx( 10.000000001 ) );
-    ut assert that( Expr( 5 + 5 ), ut approx( 10.0001, {Relative Epsilon( 1e-5 )} ) );
-    ut assert that( Expr( 0 + 0 ), ut approx( 0.1, {Zero Epsilon( .2 )} ) );
-  }}
+	Expr(Function( {val, options={Zero Epsilon( 1e-12 ), Relative Epsilon( 1e-9 )}},
+		{ze, re},
+		If( 
+			!Is Number( Name Expr( val ) ) & !Is Matrix( Name Expr( val ) ),
+				Throw("First argument for ut approx() must be a number or matrix." );
+		,
+			!Is List( options ), 
+				Throw("Second argument for ut approx() must be a list." );
+		);
+		ze = Try( options["Zero Epsilon"], 1e-12 );
+		re = Try( options["Relative Epsilon"], 1e-9 );
+		
+		If( Is Matrix( val ) & Is Matrix( re ),
+			If( !(N Col( val ) == N Col( re ) & N Row( val ) == N Row( re ) ),
+				Throw( "When the expected value and Relative Epsilon are both matrices, they must be the same size." )
+			);
+		);
+		
+		New Object( UtApproxMatcher( val, ze, re ) );
+	)),
+	"ut approx( value, <options> )",
+	"Returns a success if the relative difference between expected and actual is within the relative epsilon for non-zero values and within zero epsilon if the expected or actual value is 0. Works only on numbers and matrices.",
+	{{
+		"Simple",
+		ut assert that( Expr( 5 + 5 ), ut approx( 10.000000001 ) );
+		ut assert that( Expr( 5 + 5 ), ut approx( 10.0001, {Relative Epsilon( 1e-5 )} ) );
+		ut assert that( Expr( 0 + 0 ), ut approx( 0.1, {Zero Epsilon( .2 )} ) );
+	}}
 );
 
 /* 
@@ -248,26 +248,26 @@ ut matcher factory( "ut approx",
 		---------
 */
 ut matcher factory( "ut approx digits",
-  Expr(Function({val, digits},
-    
-    If( 
-      !Is Number( Name Expr( val ) ) & !Is Matrix( Name Expr( val ) ), 
-        Throw("First argument for ut approx digits() must be a number or matrix." );
-    ,
-      !Is Number( Name Expr( digits ) ) & !Is Matrix( Name Expr( digits ) ),
-        Throw("Second argument for ut approx digits() must be a matrix or number of digits." )
-    );
-    
-    New Object( UtApproxDigitsMatcher( val, digits ) );
-  )),
-  "ut approx digits( value, digits )",
-  "Returns a success if the actual value matches the expected value up to N digits. Works only on numbers and matrices.",
-  {{
-    "Simple",
-    ut assert that( Expr( 5 + 5 ), ut approx digits( 10.001, 4 ) );
+	Expr(Function({val, digits},
+		
+		If( 
+			!Is Number( Name Expr( val ) ) & !Is Matrix( Name Expr( val ) ), 
+				Throw("First argument for ut approx digits() must be a number or matrix." );
+		,
+			!Is Number( Name Expr( digits ) ) & !Is Matrix( Name Expr( digits ) ),
+				Throw("Second argument for ut approx digits() must be a matrix or number of digits." )
+		);
+		
+		New Object( UtApproxDigitsMatcher( val, digits ) );
+	)),
+	"ut approx digits( value, digits )",
+	"Returns a success if the actual value matches the expected value up to N digits. Works only on numbers and matrices.",
+	{{
+		"Simple",
+		ut assert that( Expr( 5 + 5 ), ut approx digits( 10.001, 4 ) );
 		ut assert that( Expr( 0 + 0 ), ut approx digits( 0.1, 1 ) );
 		ut assert that( expr( [5] + [5] ), ut approx digits( [10.1], [2] ) )
-  }}
+	}}
 );
 
 /* 
@@ -276,7 +276,7 @@ ut matcher factory( "ut approx digits",
 		ut min lre( number val, number minLRE )
 		---------------
 		Returns a success if LRE of actual value and expected value is above
-    a given threshold.
+		a given threshold.
 		
 		Works only on numbers and matrices.
 		
@@ -292,17 +292,17 @@ ut matcher factory( "ut approx digits",
 		---------
 */
 ut matcher factory( "ut min lre",
-  Expr(Function({val, mLRE},
-    If( 
-      !Is Number( Name Expr( val ) ) & !Is Matrix( Name Expr( val ) ),
-        Throw("First argument for ut min lre() must be a number or matrix." );
-    ,
-      !Is Number( Name Expr( mLRE ) ) & !Is Matrix( Name Expr( mLRE ) ),
-        Throw("Second argument for ut min lre() must be a number or matrix." );
-    );
-    New Object( UtMinLREMatcher( val, mLRE ) )
-  )),
-  "ut min lre( value, minLRE )",
-  "Returns a success if LRE of actual value and expected value is above a given threshold. Works only on numbers and matrices.",
-  {{"Simple", ut assert that( Expr( 5 + 5 ), ut min lre( 10.1, 2 ) );}}
+	Expr(Function({val, mLRE},
+		If( 
+			!Is Number( Name Expr( val ) ) & !Is Matrix( Name Expr( val ) ),
+				Throw("First argument for ut min lre() must be a number or matrix." );
+		,
+			!Is Number( Name Expr( mLRE ) ) & !Is Matrix( Name Expr( mLRE ) ),
+				Throw("Second argument for ut min lre() must be a number or matrix." );
+		);
+		New Object( UtMinLREMatcher( val, mLRE ) )
+	)),
+	"ut min lre( value, minLRE )",
+	"Returns a success if LRE of actual value and expected value is above a given threshold. Works only on numbers and matrices.",
+	{{"Simple", ut assert that( Expr( 5 + 5 ), ut min lre( 10.1, 2 ) );}}
 );

--- a/Source/Matchers/AsChar.jsl
+++ b/Source/Matchers/AsChar.jsl
@@ -44,10 +44,10 @@ Define Class(
 		> ut assert that( Expr( [1] || [1] ), ut as char( "[1 1]" ) )
 */
 ut matcher factory( "ut as char",
-  Expr(Function( {matcher},
-    New Object( UtAsCharMatcher( ut ensure matcher( Name Expr( matcher ) ) ) );
-  )),
-  "ut as char( value )",
-  "Compares the given string to the actual value converted to character.",
-  {{"Simple", ut assert that( Expr( [1] || [1] ), ut as char( "[1 1]" ) )}}
+	Expr(Function( {matcher},
+		New Object( UtAsCharMatcher( ut ensure matcher( Name Expr( matcher ) ) ) );
+	)),
+	"ut as char( value )",
+	"Compares the given string to the actual value converted to character.",
+	{{"Simple", ut assert that( Expr( [1] || [1] ), ut as char( "[1 1]" ) )}}
 );

--- a/Source/Matchers/AsChar.jsl
+++ b/Source/Matchers/AsChar.jsl
@@ -43,7 +43,11 @@ Define Class(
 	Examples:
 		> ut assert that( Expr( [1] || [1] ), ut as char( "[1 1]" ) )
 */
-ut matcher factory( "ut as char" );
-ut as char = Function( {matcher},
-	New Object( UtAsCharMatcher( ut ensure matcher( Name Expr( matcher ) ) ) );
+ut matcher factory( "ut as char",
+  Expr(Function( {matcher},
+    New Object( UtAsCharMatcher( ut ensure matcher( Name Expr( matcher ) ) ) );
+  )),
+  "ut as char( value )",
+  "Compares the given string to the actual value converted to character.",
+  {{"Simple", ut assert that( Expr( [1] || [1] ), ut as char( "[1 1]" ) )}}
 );

--- a/Source/Matchers/Case.jsl
+++ b/Source/Matchers/Case.jsl
@@ -50,12 +50,12 @@ Define Class(
 		> ut assert that( Expr( "Test" || "string" ), ut as lowercase( "teststring" ) );
 */
 ut matcher factory( "ut as lowercase",
-  Expr(Function( {matcher},
-    New Object( UtCaseMatcher( ut ensure matcher( Name Expr( matcher ) ), "Lowercase", "lowercase" ) )
-  )),
-  "ut as lowercase( matcher )",
-  "Converts actual value to lowercase before passing it to an inner matcher (or equal to if one is not provided).",
-  {{"Simple", ut assert that( Expr( "Test" || "string" ), ut as lowercase( "teststring" ) )}}
+	Expr(Function( {matcher},
+		New Object( UtCaseMatcher( ut ensure matcher( Name Expr( matcher ) ), "Lowercase", "lowercase" ) )
+	)),
+	"ut as lowercase( matcher )",
+	"Converts actual value to lowercase before passing it to an inner matcher (or equal to if one is not provided).",
+	{{"Simple", ut assert that( Expr( "Test" || "string" ), ut as lowercase( "teststring" ) )}}
 );
 
 /* 
@@ -75,10 +75,10 @@ ut matcher factory( "ut as lowercase",
 		> ut assert that( Expr( "Test" || "string" ), ut as uppercase( "TESTSTRING" ) );
 */
 ut matcher factory( "ut as uppercase",
-  Expr(Function( {matcher},
-    New Object( UtCaseMatcher( ut ensure matcher( Name Expr( matcher ) ), "Uppercase", "uppercase" ) )
-  )),
-  "ut as uppercase( matcher )",
-  "Converts actual value to uppercase before passing it to an inner matcher (or equal to if one is not provided).",
-  {{"Simple", ut assert that( Expr( "Test" || "string" ), ut as uppercase( "TESTSTRING" ) );}}
+	Expr(Function( {matcher},
+		New Object( UtCaseMatcher( ut ensure matcher( Name Expr( matcher ) ), "Uppercase", "uppercase" ) )
+	)),
+	"ut as uppercase( matcher )",
+	"Converts actual value to uppercase before passing it to an inner matcher (or equal to if one is not provided).",
+	{{"Simple", ut assert that( Expr( "Test" || "string" ), ut as uppercase( "TESTSTRING" ) );}}
 );

--- a/Source/Matchers/Case.jsl
+++ b/Source/Matchers/Case.jsl
@@ -49,9 +49,13 @@ Define Class(
 	Examples:
 		> ut assert that( Expr( "Test" || "string" ), ut as lowercase( "teststring" ) );
 */
-ut matcher factory( "ut as lowercase" );
-ut as lowercase = Function( {matcher},
-	New Object( UtCaseMatcher( ut ensure matcher( Name Expr( matcher ) ), "Lowercase", "lowercase" ) )
+ut matcher factory( "ut as lowercase",
+  Expr(Function( {matcher},
+    New Object( UtCaseMatcher( ut ensure matcher( Name Expr( matcher ) ), "Lowercase", "lowercase" ) )
+  )),
+  "ut as lowercase( matcher )",
+  "Converts actual value to lowercase before passing it to an inner matcher (or equal to if one is not provided).",
+  {{"Simple", ut assert that( Expr( "Test" || "string" ), ut as lowercase( "teststring" ) )}}
 );
 
 /* 
@@ -70,7 +74,11 @@ ut as lowercase = Function( {matcher},
 	Examples:
 		> ut assert that( Expr( "Test" || "string" ), ut as uppercase( "TESTSTRING" ) );
 */
-ut matcher factory( "ut as uppercase" );
-ut as uppercase = Function( {matcher},
-	New Object( UtCaseMatcher( ut ensure matcher( Name Expr( matcher ) ), "Uppercase", "uppercase" ) )
+ut matcher factory( "ut as uppercase",
+  Expr(Function( {matcher},
+    New Object( UtCaseMatcher( ut ensure matcher( Name Expr( matcher ) ), "Uppercase", "uppercase" ) )
+  )),
+  "ut as uppercase( matcher )",
+  "Converts actual value to uppercase before passing it to an inner matcher (or equal to if one is not provided).",
+  {{"Simple", ut assert that( Expr( "Test" || "string" ), ut as uppercase( "TESTSTRING" ) );}}
 );

--- a/Source/Matchers/Close.jsl
+++ b/Source/Matchers/Close.jsl
@@ -63,10 +63,14 @@ Define Class(
 	Example:
 		> ut assert that( Expr( 5 + 5 ), ut close to( 10, 0.01 ) );
 */
-ut matcher factory( "ut close to" );
-ut close to = Function( {val, delta},
-	If( Is Number( val ) & Is Number(delta),
-		New Object( UtCloseMatcher( val, delta ) ),
-		Throw( "Both value and delta arguments for ut close to() must be numeric." )
-	)
+ut matcher factory( "ut close to",
+  Expr(Function( {val, delta},
+    If( Is Number( val ) & Is Number(delta),
+      New Object( UtCloseMatcher( val, delta ) ),
+      Throw( "Both value and delta arguments for ut close to() must be numeric." )
+    )
+  )),
+  "ut close to( value, delta )",
+  "Returns a success if the actual value is within the delta of the expected value.",
+  {{"Simple", ut assert that( Expr( 5 + 5 ), ut close to( 10, 0.01 ) ); }}
 );

--- a/Source/Matchers/Close.jsl
+++ b/Source/Matchers/Close.jsl
@@ -64,13 +64,13 @@ Define Class(
 		> ut assert that( Expr( 5 + 5 ), ut close to( 10, 0.01 ) );
 */
 ut matcher factory( "ut close to",
-  Expr(Function( {val, delta},
-    If( Is Number( val ) & Is Number(delta),
-      New Object( UtCloseMatcher( val, delta ) ),
-      Throw( "Both value and delta arguments for ut close to() must be numeric." )
-    )
-  )),
-  "ut close to( value, delta )",
-  "Returns a success if the actual value is within the delta of the expected value.",
-  {{"Simple", ut assert that( Expr( 5 + 5 ), ut close to( 10, 0.01 ) ); }}
+	Expr(Function( {val, delta},
+		If( Is Number( val ) & Is Number(delta),
+			New Object( UtCloseMatcher( val, delta ) ),
+			Throw( "Both value and delta arguments for ut close to() must be numeric." )
+		)
+	)),
+	"ut close to( value, delta )",
+	"Returns a success if the actual value is within the delta of the expected value.",
+	{{"Simple", ut assert that( Expr( 5 + 5 ), ut close to( 10, 0.01 ) ); }}
 );

--- a/Source/Matchers/Contains.jsl
+++ b/Source/Matchers/Contains.jsl
@@ -98,19 +98,19 @@ Define Class(
 		> ut assert that( Expr( "Test" || "string" ), ut contains( "string" ) );
 */
 ut matcher factory( "ut contains",
-  Expr(Function( {val},
-    {obj},
-    If( !ut is a matcher( Name Expr( val ) ), 
-      obj = New Object( UtContainsMatcher() );
-      obj:value = Name Expr( val );
-      obj;
-    ,
-      Throw( "ut contains() does not allow for inner matchers. Use ut contains item() for inner matchers for lists." )
-    );
-  )),
-  "ut contains( value )",
-  "Uses built-in Contains() function to check if the actual value contains the expected value.",
-  {{"Simple", ut assert that( Expr( {1, 2, 3} ), ut contains( 3 ) ); ut assert that( Expr( "Test" || "string" ), ut contains( "string" ) );}}
+	Expr(Function( {val},
+		{obj},
+		If( !ut is a matcher( Name Expr( val ) ), 
+			obj = New Object( UtContainsMatcher() );
+			obj:value = Name Expr( val );
+			obj;
+		,
+			Throw( "ut contains() does not allow for inner matchers. Use ut contains item() for inner matchers for lists." )
+		);
+	)),
+	"ut contains( value )",
+	"Uses built-in Contains() function to check if the actual value contains the expected value.",
+	{{"Simple", ut assert that( Expr( {1, 2, 3} ), ut contains( 3 ) ); ut assert that( Expr( "Test" || "string" ), ut contains( "string" ) );}}
 );
 
 /* 
@@ -130,10 +130,10 @@ ut matcher factory( "ut contains",
 		> ut assert that( Expr( {a( 1 ), b( 2 ), c( 3 )} ), ut contains item( Expr( b( ut wild() ) ) ) );
 */
 ut matcher factory( "ut contains item",
-  Expr(Function( {matcher},
-    New Object( UtContainsItemMatcher( ut ensure matcher( Name Expr( matcher ) ) ) );
-  )),
-  "ut contains item( matcher )",
-  "Checks if the actual value contains the expected value. Expected value can be an inner matcher if the actual result is a list.",
-  {{"Simple", ut assert that( Expr( {a( 1 ), b( 2 ), c( 3 )} ), ut contains item( Expr( b( ut wild() ) ) ) ); }}
+	Expr(Function( {matcher},
+		New Object( UtContainsItemMatcher( ut ensure matcher( Name Expr( matcher ) ) ) );
+	)),
+	"ut contains item( matcher )",
+	"Checks if the actual value contains the expected value. Expected value can be an inner matcher if the actual result is a list.",
+	{{"Simple", ut assert that( Expr( {a( 1 ), b( 2 ), c( 3 )} ), ut contains item( Expr( b( ut wild() ) ) ) ); }}
 );

--- a/Source/Matchers/Contains.jsl
+++ b/Source/Matchers/Contains.jsl
@@ -97,16 +97,20 @@ Define Class(
 		> ut assert that( Expr( {1, 2, 3} ), ut contains( 3 ) );
 		> ut assert that( Expr( "Test" || "string" ), ut contains( "string" ) );
 */
-ut matcher factory( "ut contains" );
-ut contains = Function( {val},
-	{obj},
-	If( !ut is a matcher( Name Expr( val ) ), 
-		obj = New Object( UtContainsMatcher() );
-		obj:value = Name Expr( val );
-		obj;
-	,
-		Throw( "ut contains() does not allow for inner matchers. Use ut contains item() for inner matchers for lists." )
-	);
+ut matcher factory( "ut contains",
+  Expr(Function( {val},
+    {obj},
+    If( !ut is a matcher( Name Expr( val ) ), 
+      obj = New Object( UtContainsMatcher() );
+      obj:value = Name Expr( val );
+      obj;
+    ,
+      Throw( "ut contains() does not allow for inner matchers. Use ut contains item() for inner matchers for lists." )
+    );
+  )),
+  "ut contains( value )",
+  "Uses built-in Contains() function to check if the actual value contains the expected value.",
+  {{"Simple", ut assert that( Expr( {1, 2, 3} ), ut contains( 3 ) ); ut assert that( Expr( "Test" || "string" ), ut contains( "string" ) );}}
 );
 
 /* 
@@ -125,7 +129,11 @@ ut contains = Function( {val},
 	Examples:
 		> ut assert that( Expr( {a( 1 ), b( 2 ), c( 3 )} ), ut contains item( Expr( b( ut wild() ) ) ) );
 */
-ut matcher factory( "ut contains item" );
-ut contains item = Function( {matcher},
-	New Object( UtContainsItemMatcher( ut ensure matcher( Name Expr( matcher ) ) ) );
+ut matcher factory( "ut contains item",
+  Expr(Function( {matcher},
+    New Object( UtContainsItemMatcher( ut ensure matcher( Name Expr( matcher ) ) ) );
+  )),
+  "ut contains item( matcher )",
+  "Checks if the actual value contains the expected value. Expected value can be an inner matcher if the actual result is a list.",
+  {{"Simple", ut assert that( Expr( {a( 1 ), b( 2 ), c( 3 )} ), ut contains item( Expr( b( ut wild() ) ) ) ); }}
 );

--- a/Source/Matchers/ElapsedTime.jsl
+++ b/Source/Matchers/ElapsedTime.jsl
@@ -48,7 +48,11 @@ Define Class(
 	Example:
 		> ut assert that( Expr( Wait( 2 ) ), ut elapsed time( ut greater than or equal to( 2 ) ) );
 */
-ut matcher factory( "ut elapsed time" );
-ut elapsed time = Function( {matcher},
-	New Object( UtElapsedTimeMatcher( ut ensure matcher( Name Expr( matcher ) ) ) )
+ut matcher factory( "ut elapsed time",
+  Expr(Function( {matcher},
+    New Object( UtElapsedTimeMatcher( ut ensure matcher( Name Expr( matcher ) ) ) )
+  )),
+  "ut elapsed time( matcher )",
+  "Captures the amount of time it takes for the test expression to evaluate. Accurate up to the microsecond, but compares in seconds.",
+  {{"Simple", ut assert that( Expr( Wait( 2 ) ), ut elapsed time( ut greater than or equal to( 2 ) ) ); }}
 );

--- a/Source/Matchers/ElapsedTime.jsl
+++ b/Source/Matchers/ElapsedTime.jsl
@@ -49,10 +49,10 @@ Define Class(
 		> ut assert that( Expr( Wait( 2 ) ), ut elapsed time( ut greater than or equal to( 2 ) ) );
 */
 ut matcher factory( "ut elapsed time",
-  Expr(Function( {matcher},
-    New Object( UtElapsedTimeMatcher( ut ensure matcher( Name Expr( matcher ) ) ) )
-  )),
-  "ut elapsed time( matcher )",
-  "Captures the amount of time it takes for the test expression to evaluate. Accurate up to the microsecond, but compares in seconds.",
-  {{"Simple", ut assert that( Expr( Wait( 2 ) ), ut elapsed time( ut greater than or equal to( 2 ) ) ); }}
+	Expr(Function( {matcher},
+		New Object( UtElapsedTimeMatcher( ut ensure matcher( Name Expr( matcher ) ) ) )
+	)),
+	"ut elapsed time( matcher )",
+	"Captures the amount of time it takes for the test expression to evaluate. Accurate up to the microsecond, but compares in seconds.",
+	{{"Simple", ut assert that( Expr( Wait( 2 ) ), ut elapsed time( ut greater than or equal to( 2 ) ) ); }}
 );

--- a/Source/Matchers/Empty.jsl
+++ b/Source/Matchers/Empty.jsl
@@ -42,7 +42,12 @@ Define Class(
 	Example:
 		> ut assert that( Expr( Empty() ), ut empty() );
 */
-ut matcher factory( "ut empty" );
-ut empty = Function( {},
-	New Object( UtEmptyMatcher() );
+ut matcher factory( 
+  "ut empty",
+  Expr(Function( {},
+    New Object( UtEmptyMatcher() );
+  )),
+  "ut empty()",
+  "Uses the built-in Empty() function to determine if something is empty.",
+  {{"Simple", ut assert that( Expr( Empty() ), ut empty() ); }}
 );

--- a/Source/Matchers/Empty.jsl
+++ b/Source/Matchers/Empty.jsl
@@ -43,11 +43,11 @@ Define Class(
 		> ut assert that( Expr( Empty() ), ut empty() );
 */
 ut matcher factory( 
-  "ut empty",
-  Expr(Function( {},
-    New Object( UtEmptyMatcher() );
-  )),
-  "ut empty()",
-  "Uses the built-in Empty() function to determine if something is empty.",
-  {{"Simple", ut assert that( Expr( Empty() ), ut empty() ); }}
+	"ut empty",
+	Expr(Function( {},
+		New Object( UtEmptyMatcher() );
+	)),
+	"ut empty()",
+	"Uses the built-in Empty() function to determine if something is empty.",
+	{{"Simple", ut assert that( Expr( Empty() ), ut empty() ); }}
 );

--- a/Source/Matchers/Every.jsl
+++ b/Source/Matchers/Every.jsl
@@ -70,16 +70,16 @@ Define Class(
 		> ut assert that( Expr( {1,2,3,4,5,6} ), ut every item( ut greater than( 0 ) ) );
 */
 ut matcher factory( 
-  "ut every item",
-  Expr(Function( {matcher},
-    New Object( UtEveryMatcher( ut ensure matcher( Name Expr( matcher ) ) ) )
-  )),
-  "ut every item( matcher )",
-  "Uses inner matcher on every item of a list or matrix.",
-  {{
-    "Simple",
-    ut assert that( Expr( [1 1,1 1] || [1, 1] ), ut every item( 1 ) );
+	"ut every item",
+	Expr(Function( {matcher},
+		New Object( UtEveryMatcher( ut ensure matcher( Name Expr( matcher ) ) ) )
+	)),
+	"ut every item( matcher )",
+	"Uses inner matcher on every item of a list or matrix.",
+	{{
+		"Simple",
+		ut assert that( Expr( [1 1,1 1] || [1, 1] ), ut every item( 1 ) );
 		ut assert that( Expr( {2,2,2,2,2} ), ut every item( 2 ) );
 		ut assert that( Expr( {1,2,3,4,5,6} ), ut every item( ut greater than( 0 ) ) );
-  }}
+	}}
 );

--- a/Source/Matchers/Every.jsl
+++ b/Source/Matchers/Every.jsl
@@ -69,7 +69,17 @@ Define Class(
 		> ut assert that( Expr( {2,2,2,2,2} ), ut every item( 2 ) );
 		> ut assert that( Expr( {1,2,3,4,5,6} ), ut every item( ut greater than( 0 ) ) );
 */
-ut matcher factory( "ut every item" );
-ut every item = Function( {matcher},
-	New Object( UtEveryMatcher( ut ensure matcher( Name Expr( matcher ) ) ) )
+ut matcher factory( 
+  "ut every item",
+  Expr(Function( {matcher},
+    New Object( UtEveryMatcher( ut ensure matcher( Name Expr( matcher ) ) ) )
+  )),
+  "ut every item( matcher )",
+  "Uses inner matcher on every item of a list or matrix.",
+  {{
+    "Simple",
+    ut assert that( Expr( [1 1,1 1] || [1, 1] ), ut every item( 1 ) );
+		ut assert that( Expr( {2,2,2,2,2} ), ut every item( 2 ) );
+		ut assert that( Expr( {1,2,3,4,5,6} ), ut every item( ut greater than( 0 ) ) );
+  }}
 );

--- a/Source/Matchers/Host.jsl
+++ b/Source/Matchers/Host.jsl
@@ -86,9 +86,14 @@ ut host specific = Function( {matcher1, matcher2},
 	Examples:
 		> ut assert that( Expr( Get Default Directory() ), ut on windows( ut starts with( "/C:/" ) ) );
 */
-ut matcher factory( "ut on windows" );
-ut on windows = Function( {matcher},
-	New Object( UtHostMatcher( ut ensure matcher( Name Expr( matcher ) ), "Windows" ) );
+ut matcher factory( 
+  "ut on windows",
+  Expr(Function( {matcher},
+    New Object( UtHostMatcher( ut ensure matcher( Name Expr( matcher ) ), "Windows" ) );
+  )),
+  "ut on windows( matcher )",
+  "Only runs the test if on a Windows host. Returns a success if running on a Mac.",
+  {{"Simple", ut assert that( Expr( Get Default Directory() ), ut on windows( ut starts with( "/C:/" ) ) ); }}
 );
 
 /* 
@@ -106,9 +111,14 @@ ut on windows = Function( {matcher},
 	Examples:
 		> ut assert that( Expr( Get Default Directory() ), ut on mac( ut not( ut starts with( "/C:/" ) ) ) );
 */
-ut matcher factory( "ut on mac" );
-ut on mac = Function( {matcher},
-	New Object( UtHostMatcher( ut ensure matcher( Name Expr( matcher ) ), "Mac" ) );
+ut matcher factory( 
+  "ut on mac",
+  Expr(Function( {matcher},
+    New Object( UtHostMatcher( ut ensure matcher( Name Expr( matcher ) ), "Mac" ) );
+  )),
+  "ut on mac( matcher )",
+  "Only runs the test if on a Mac host. Returns a success if running on a Windows.",
+  {{"Simple", ut assert that( Expr( Get Default Directory() ), ut on mac( ut not( ut starts with( "/C:/" ) ) ) ); }}
 );
 
 /* 
@@ -129,11 +139,20 @@ ut on mac = Function( {matcher},
 		ut assert that( Expr( dt << Get Name ), ut host table name( "Big Class" ) );
 		---------
 */
-ut matcher factory( "ut host table name" );
-ut host table name = Function( {name},
-	If( Is String( name ),
-		ut equal to( ut host table name str( name ) );
-	,
-		Throw( "ut host table name() matcher requires a string as the argument (a Windows table name--without '.jmp')" )
-	);
+ut matcher factory( 
+  "ut host table name",
+  Expr(Function( {name},
+    If( Is String( name ),
+      ut equal to( ut host table name str( name ) );
+    ,
+      Throw( "ut host table name() matcher requires a string as the argument (a Windows table name--without '.jmp')" )
+    );
+  )),
+  "ut host table name( name )",
+  "Returns an equal to matcher that converts a string to a host specific table name string.",
+  {{
+    "Simple",
+    dt = Open( "$SAMPLE_DATA\Big Class.jmp" );
+		ut assert that( Expr( dt << Get Name ), ut host table name( "Big Class" ) );
+  }}
 );

--- a/Source/Matchers/Host.jsl
+++ b/Source/Matchers/Host.jsl
@@ -87,13 +87,13 @@ ut host specific = Function( {matcher1, matcher2},
 		> ut assert that( Expr( Get Default Directory() ), ut on windows( ut starts with( "/C:/" ) ) );
 */
 ut matcher factory( 
-  "ut on windows",
-  Expr(Function( {matcher},
-    New Object( UtHostMatcher( ut ensure matcher( Name Expr( matcher ) ), "Windows" ) );
-  )),
-  "ut on windows( matcher )",
-  "Only runs the test if on a Windows host. Returns a success if running on a Mac.",
-  {{"Simple", ut assert that( Expr( Get Default Directory() ), ut on windows( ut starts with( "/C:/" ) ) ); }}
+	"ut on windows",
+	Expr(Function( {matcher},
+		New Object( UtHostMatcher( ut ensure matcher( Name Expr( matcher ) ), "Windows" ) );
+	)),
+	"ut on windows( matcher )",
+	"Only runs the test if on a Windows host. Returns a success if running on a Mac.",
+	{{"Simple", ut assert that( Expr( Get Default Directory() ), ut on windows( ut starts with( "/C:/" ) ) ); }}
 );
 
 /* 
@@ -112,13 +112,13 @@ ut matcher factory(
 		> ut assert that( Expr( Get Default Directory() ), ut on mac( ut not( ut starts with( "/C:/" ) ) ) );
 */
 ut matcher factory( 
-  "ut on mac",
-  Expr(Function( {matcher},
-    New Object( UtHostMatcher( ut ensure matcher( Name Expr( matcher ) ), "Mac" ) );
-  )),
-  "ut on mac( matcher )",
-  "Only runs the test if on a Mac host. Returns a success if running on a Windows.",
-  {{"Simple", ut assert that( Expr( Get Default Directory() ), ut on mac( ut not( ut starts with( "/C:/" ) ) ) ); }}
+	"ut on mac",
+	Expr(Function( {matcher},
+		New Object( UtHostMatcher( ut ensure matcher( Name Expr( matcher ) ), "Mac" ) );
+	)),
+	"ut on mac( matcher )",
+	"Only runs the test if on a Mac host. Returns a success if running on a Windows.",
+	{{"Simple", ut assert that( Expr( Get Default Directory() ), ut on mac( ut not( ut starts with( "/C:/" ) ) ) ); }}
 );
 
 /* 
@@ -140,19 +140,19 @@ ut matcher factory(
 		---------
 */
 ut matcher factory( 
-  "ut host table name",
-  Expr(Function( {name},
-    If( Is String( name ),
-      ut equal to( ut host table name str( name ) );
-    ,
-      Throw( "ut host table name() matcher requires a string as the argument (a Windows table name--without '.jmp')" )
-    );
-  )),
-  "ut host table name( name )",
-  "Returns an equal to matcher that converts a string to a host specific table name string.",
-  {{
-    "Simple",
-    dt = Open( "$SAMPLE_DATA\Big Class.jmp" );
+	"ut host table name",
+	Expr(Function( {name},
+		If( Is String( name ),
+			ut equal to( ut host table name str( name ) );
+		,
+			Throw( "ut host table name() matcher requires a string as the argument (a Windows table name--without '.jmp')" )
+		);
+	)),
+	"ut host table name( name )",
+	"Returns an equal to matcher that converts a string to a host specific table name string.",
+	{{
+		"Simple",
+		dt = Open( "$SAMPLE_DATA\Big Class.jmp" );
 		ut assert that( Expr( dt << Get Name ), ut host table name( "Big Class" ) );
-  }}
+	}}
 );

--- a/Source/Matchers/Host.jsl
+++ b/Source/Matchers/Host.jsl
@@ -93,7 +93,7 @@ ut matcher factory(
 	)),
 	"ut on windows( matcher )",
 	"Only runs the test if on a Windows host. Returns a success if running on a Mac.",
-	{{"Simple", ut assert that( Expr( Get Default Directory() ), ut on windows( ut starts with( "/C:/" ) ) ); }}
+	{{"Simple", ut assert that( Expr( Get Path Variable( "Documents" ) ), ut on windows( ut starts with( "/C:/" ) ) ); }}
 );
 
 /* 

--- a/Source/Matchers/IgnoringCase.jsl
+++ b/Source/Matchers/IgnoringCase.jsl
@@ -55,10 +55,16 @@ Define Class(
 	Examples:
 		> ut assert that( Expr( "st" || "ring"), ut equal to ignoring case( "STRING" ) )
 */
-ut matcher factory( "ut equal to ignoring case" );
-ut equal to ignoring case = Function( {val},
-	If( Is String( val ),
-		New Object( UtIgnoringCaseMatcher( val ) ),
-		Throw( "ut equal to ignoring case() requires a string as the argument" )
-	);
+ut matcher factory( 
+  "ut equal to ignoring case",
+  Expr(Function( {val},
+    If( Is String( val ),
+      New Object( UtIgnoringCaseMatcher( val ) ),
+      Throw( "ut equal to ignoring case() requires a string as the argument" )
+    );
+  )),
+  "ut equal to ignoring case( value )",
+  "Compares actual value ingoring the case. This matcher requires the expected to be a string (and not a matcher).\!n\!n" || 
+  "To use an inner matcher, instead use ut as lowercase or ut as uppercase and use an expected string that matches the chosen matcher.",
+  {{"Simple", ut assert that( Expr( "st" || "ring"), ut equal to ignoring case( "STRING" ) ); }}
 );

--- a/Source/Matchers/IgnoringCase.jsl
+++ b/Source/Matchers/IgnoringCase.jsl
@@ -56,15 +56,15 @@ Define Class(
 		> ut assert that( Expr( "st" || "ring"), ut equal to ignoring case( "STRING" ) )
 */
 ut matcher factory( 
-  "ut equal to ignoring case",
-  Expr(Function( {val},
-    If( Is String( val ),
-      New Object( UtIgnoringCaseMatcher( val ) ),
-      Throw( "ut equal to ignoring case() requires a string as the argument" )
-    );
-  )),
-  "ut equal to ignoring case( value )",
-  "Compares actual value ingoring the case. This matcher requires the expected to be a string (and not a matcher).\!n\!n" || 
-  "To use an inner matcher, instead use ut as lowercase or ut as uppercase and use an expected string that matches the chosen matcher.",
-  {{"Simple", ut assert that( Expr( "st" || "ring"), ut equal to ignoring case( "STRING" ) ); }}
+	"ut equal to ignoring case",
+	Expr(Function( {val},
+		If( Is String( val ),
+			New Object( UtIgnoringCaseMatcher( val ) ),
+			Throw( "ut equal to ignoring case() requires a string as the argument" )
+		);
+	)),
+	"ut equal to ignoring case( value )",
+	"Compares actual value ingoring the case. This matcher requires the expected to be a string (and not a matcher).\!n\!n" || 
+	"To use an inner matcher, instead use ut as lowercase or ut as uppercase and use an expected string that matches the chosen matcher.",
+	{{"Simple", ut assert that( Expr( "st" || "ring"), ut equal to ignoring case( "STRING" ) ); }}
 );

--- a/Source/Matchers/IgnoringWhitespace.jsl
+++ b/Source/Matchers/IgnoringWhitespace.jsl
@@ -49,12 +49,21 @@ Define Class(
 		> ut assert that( Expr( "  test " || " test   " ), ut equal to ignoring whitespace( "test    test" ) );
 		> ut assert that( Expr( Show( 5 + 5 ) ), ut log is( ut equal to ignoring whitespace( "5 + 5 = 10;" ) ) );
 */
-ut matcher factory( "ut equal to ignoring whitespace" );
-ut equal to ignoring whitespace = Function( {val},
-	If( Is String( name expr( val ) ),
-		New Object( UtIgnoringWhitespaceMatcher( ut equal to( Collapse Whitespace( val ) ) ) ),
-		Throw( "ut equal to ignoring whitespace() requires a string as the argument" )
-	);
+ut matcher factory( 
+  "ut equal to ignoring whitespace",
+  Expr(Function( {val},
+    If( Is String( name expr( val ) ),
+      New Object( UtIgnoringWhitespaceMatcher( ut equal to( Collapse Whitespace( val ) ) ) ),
+      Throw( "ut equal to ignoring whitespace() requires a string as the argument" )
+    );
+  )),
+  "ut equal to ignoring whitespace( value )",
+  "Collapses the whitespace of the actual expression. Expected value should be a string, and whitespace will be automatically be collapsed on the expected value, in addition to the actual. To use an inner matcher, see <ut ignoring whitespace>.",
+  {{
+    "Simple",
+    ut assert that( Expr( "  test " || " test   " ), ut equal to ignoring whitespace( "test    test" ) );
+		ut assert that( Expr( Show( 5 + 5 ) ), ut log is( ut equal to ignoring whitespace( "5 + 5 = 10;" ) ) );
+  }}
 );
 
 /*
@@ -76,7 +85,17 @@ ut equal to ignoring whitespace = Function( {val},
 		> ut assert that( Expr( "  test " || " test   " ), ut ignoring whitespace( ut starts with( "test t" ) ) );
 		> ut assert that( Expr( Show( 5 + 5 ) ), ut log is( ut ignoring whitespace( "5 + 5 = 10;" ) ) );
 */
-ut matcher factory( "ut ignoring whitespace" );
-ut ignoring whitespace = Function( {matcher},
-	New Object( UtIgnoringWhitespaceMatcher( ut ensure matcher( matcher ) ) );
+ut matcher factory( 
+  "ut ignoring whitespace",
+  Expr(Function( {matcher},
+    New Object( UtIgnoringWhitespaceMatcher( ut ensure matcher( matcher ) ) );
+  )),
+  "ut ignoring whitespace( matcher )",
+  "Collapses the whitespace of the actual expression only. Expected string should have whitespace already collapsed.",
+  {{
+    "Simple",
+    ut assert that( Expr( "  test " || " test   " ), ut ignoring whitespace( "test test" ) );
+		ut assert that( Expr( "  test " || " test   " ), ut ignoring whitespace( ut starts with( "test t" ) ) );
+		ut assert that( Expr( Show( 5 + 5 ) ), ut log is( ut ignoring whitespace( "5 + 5 = 10;" ) ) );
+  }}
 );

--- a/Source/Matchers/IgnoringWhitespace.jsl
+++ b/Source/Matchers/IgnoringWhitespace.jsl
@@ -50,20 +50,20 @@ Define Class(
 		> ut assert that( Expr( Show( 5 + 5 ) ), ut log is( ut equal to ignoring whitespace( "5 + 5 = 10;" ) ) );
 */
 ut matcher factory( 
-  "ut equal to ignoring whitespace",
-  Expr(Function( {val},
-    If( Is String( name expr( val ) ),
-      New Object( UtIgnoringWhitespaceMatcher( ut equal to( Collapse Whitespace( val ) ) ) ),
-      Throw( "ut equal to ignoring whitespace() requires a string as the argument" )
-    );
-  )),
-  "ut equal to ignoring whitespace( value )",
-  "Collapses the whitespace of the actual expression. Expected value should be a string, and whitespace will be automatically be collapsed on the expected value, in addition to the actual. To use an inner matcher, see <ut ignoring whitespace>.",
-  {{
-    "Simple",
-    ut assert that( Expr( "  test " || " test   " ), ut equal to ignoring whitespace( "test    test" ) );
+	"ut equal to ignoring whitespace",
+	Expr(Function( {val},
+		If( Is String( name expr( val ) ),
+			New Object( UtIgnoringWhitespaceMatcher( ut equal to( Collapse Whitespace( val ) ) ) ),
+			Throw( "ut equal to ignoring whitespace() requires a string as the argument" )
+		);
+	)),
+	"ut equal to ignoring whitespace( value )",
+	"Collapses the whitespace of the actual expression. Expected value should be a string, and whitespace will be automatically be collapsed on the expected value, in addition to the actual. To use an inner matcher, see <ut ignoring whitespace>.",
+	{{
+		"Simple",
+		ut assert that( Expr( "  test " || " test   " ), ut equal to ignoring whitespace( "test    test" ) );
 		ut assert that( Expr( Show( 5 + 5 ) ), ut log is( ut equal to ignoring whitespace( "5 + 5 = 10;" ) ) );
-  }}
+	}}
 );
 
 /*
@@ -86,16 +86,16 @@ ut matcher factory(
 		> ut assert that( Expr( Show( 5 + 5 ) ), ut log is( ut ignoring whitespace( "5 + 5 = 10;" ) ) );
 */
 ut matcher factory( 
-  "ut ignoring whitespace",
-  Expr(Function( {matcher},
-    New Object( UtIgnoringWhitespaceMatcher( ut ensure matcher( matcher ) ) );
-  )),
-  "ut ignoring whitespace( matcher )",
-  "Collapses the whitespace of the actual expression only. Expected string should have whitespace already collapsed.",
-  {{
-    "Simple",
-    ut assert that( Expr( "  test " || " test   " ), ut ignoring whitespace( "test test" ) );
+	"ut ignoring whitespace",
+	Expr(Function( {matcher},
+		New Object( UtIgnoringWhitespaceMatcher( ut ensure matcher( matcher ) ) );
+	)),
+	"ut ignoring whitespace( matcher )",
+	"Collapses the whitespace of the actual expression only. Expected string should have whitespace already collapsed.",
+	{{
+		"Simple",
+		ut assert that( Expr( "  test " || " test   " ), ut ignoring whitespace( "test test" ) );
 		ut assert that( Expr( "  test " || " test   " ), ut ignoring whitespace( ut starts with( "test t" ) ) );
 		ut assert that( Expr( Show( 5 + 5 ) ), ut log is( ut ignoring whitespace( "5 + 5 = 10;" ) ) );
-  }}
+	}}
 );

--- a/Source/Matchers/InstanceOf.jsl
+++ b/Source/Matchers/InstanceOf.jsl
@@ -52,12 +52,21 @@ Define Class(
 		ut assert that( Expr( New Object( "Foo" ) ), ut instance of( "Foo" ) );
 		---------
 */
-ut matcher factory( "ut instance of" );
-ut instance of = Function({val},
-	{obj},
-	If( !Is String( Name Expr( val ) ),
-		Throw( "argument to ut instance of() must be a string" ),
-		obj = New Object( UtInstanceOfMatcher( val ) );
-		obj:self = obj;
-	);
+ut matcher factory( 
+  "ut instance of",
+  Expr(Function({val},
+    {obj},
+    If( !Is String( Name Expr( val ) ),
+      Throw( "argument to ut instance of() must be a string" ),
+      obj = New Object( UtInstanceOfMatcher( val ) );
+      obj:self = obj;
+    );
+  )),
+  "ut instance of( value )",
+  "Checks if actual value is a class object of a specific type. This matcher does not check base class names. You may need to use duck typing and create your own matcher for this purpose.",
+  {{
+    "Simple",
+    Define Class("Foo");
+		ut assert that( Expr( New Object( "Foo" ) ), ut instance of( "Foo" ) );
+  }}
 );

--- a/Source/Matchers/InstanceOf.jsl
+++ b/Source/Matchers/InstanceOf.jsl
@@ -53,20 +53,20 @@ Define Class(
 		---------
 */
 ut matcher factory( 
-  "ut instance of",
-  Expr(Function({val},
-    {obj},
-    If( !Is String( Name Expr( val ) ),
-      Throw( "argument to ut instance of() must be a string" ),
-      obj = New Object( UtInstanceOfMatcher( val ) );
-      obj:self = obj;
-    );
-  )),
-  "ut instance of( value )",
-  "Checks if actual value is a class object of a specific type. This matcher does not check base class names. You may need to use duck typing and create your own matcher for this purpose.",
-  {{
-    "Simple",
-    Define Class("Foo");
+	"ut instance of",
+	Expr(Function({val},
+		{obj},
+		If( !Is String( Name Expr( val ) ),
+			Throw( "argument to ut instance of() must be a string" ),
+			obj = New Object( UtInstanceOfMatcher( val ) );
+			obj:self = obj;
+		);
+	)),
+	"ut instance of( value )",
+	"Checks if actual value is a class object of a specific type. This matcher does not check base class names. You may need to use duck typing and create your own matcher for this purpose.",
+	{{
+		"Simple",
+		Define Class("Foo");
 		ut assert that( Expr( New Object( "Foo" ) ), ut instance of( "Foo" ) );
-  }}
+	}}
 );

--- a/Source/Matchers/Log.jsl
+++ b/Source/Matchers/Log.jsl
@@ -42,9 +42,18 @@ Define Class(
 		> ut assert that( Expr( Show( 5 + 5 ) ), ut log output( "\!N5 + 5 = 10;" ) );
 		> ut assert that( Expr( Show( 5 + 5 ) ), ut log output( ut ignoring whitespace( "5 + 5 = 10;" ) ) );
 */
-ut matcher factory( "ut log output" );
-ut log output = Function( {matcher},
-	New Object( UtLogMatcher( ut ensure matcher( Name Expr( matcher ) ) ) )
+ut matcher factory( 
+  "ut log output",
+  Expr(Function( {matcher},
+    New Object( UtLogMatcher( ut ensure matcher( Name Expr( matcher ) ) ) )
+  )),
+  "ut log output( matcher )",
+  "Passes the captured log from evaluating the test expression to the inner matcher",
+  {{
+    "Simple",
+    ut assert that( Expr( Show( 5 + 5 ) ), ut log output( "\!N5 + 5 = 10;" ) );
+		ut assert that( Expr( Show( 5 + 5 ) ), ut log output( ut ignoring whitespace( "5 + 5 = 10;" ) ) );
+  }}
 );
 
 /*
@@ -54,5 +63,10 @@ ut log output = Function( {matcher},
 		---------------
 		Alias of <ut log output>. Kept only for backwards compatibility.
 */
-ut matcher factory( "ut log is" );
-ut log is = Name Expr( ut log output );
+ut matcher factory( "ut log is", 
+  Expr(Function( {matcher},
+    New Object( UtLogMatcher( ut ensure matcher( Name Expr( matcher ) ) ) )
+  )),
+  "ut log is( matcher )", 
+  "Alias of ut log output. Kept for backwards compatibility."
+);

--- a/Source/Matchers/Log.jsl
+++ b/Source/Matchers/Log.jsl
@@ -51,8 +51,10 @@ ut matcher factory(
 	"Passes the captured log from evaluating the test expression to the inner matcher",
 	{{
 		"Simple",
-		ut assert that( Expr( Show( 5 + 5 ) ), ut log output( "\!N5 + 5 = 10;" ) );
-		ut assert that( Expr( Show( 5 + 5 ) ), ut log output( ut ignoring whitespace( "5 + 5 = 10;" ) ) );
+		"\[
+ut assert that( Expr( Show( 5 + 5 ) ), ut log output( "\!N5 + 5 = 10;" ) );
+ut assert that( Expr( Show( 5 + 5 ) ), ut log output( ut ignoring whitespace( "5 + 5 = 10;" ) ) );
+]\"
 	}}
 );
 

--- a/Source/Matchers/Log.jsl
+++ b/Source/Matchers/Log.jsl
@@ -43,17 +43,17 @@ Define Class(
 		> ut assert that( Expr( Show( 5 + 5 ) ), ut log output( ut ignoring whitespace( "5 + 5 = 10;" ) ) );
 */
 ut matcher factory( 
-  "ut log output",
-  Expr(Function( {matcher},
-    New Object( UtLogMatcher( ut ensure matcher( Name Expr( matcher ) ) ) )
-  )),
-  "ut log output( matcher )",
-  "Passes the captured log from evaluating the test expression to the inner matcher",
-  {{
-    "Simple",
-    ut assert that( Expr( Show( 5 + 5 ) ), ut log output( "\!N5 + 5 = 10;" ) );
+	"ut log output",
+	Expr(Function( {matcher},
+		New Object( UtLogMatcher( ut ensure matcher( Name Expr( matcher ) ) ) )
+	)),
+	"ut log output( matcher )",
+	"Passes the captured log from evaluating the test expression to the inner matcher",
+	{{
+		"Simple",
+		ut assert that( Expr( Show( 5 + 5 ) ), ut log output( "\!N5 + 5 = 10;" ) );
 		ut assert that( Expr( Show( 5 + 5 ) ), ut log output( ut ignoring whitespace( "5 + 5 = 10;" ) ) );
-  }}
+	}}
 );
 
 /*
@@ -64,9 +64,9 @@ ut matcher factory(
 		Alias of <ut log output>. Kept only for backwards compatibility.
 */
 ut matcher factory( "ut log is", 
-  Expr(Function( {matcher},
-    New Object( UtLogMatcher( ut ensure matcher( Name Expr( matcher ) ) ) )
-  )),
-  "ut log is( matcher )", 
-  "Alias of ut log output. Kept for backwards compatibility."
+	Expr(Function( {matcher},
+		New Object( UtLogMatcher( ut ensure matcher( Name Expr( matcher ) ) ) )
+	)),
+	"ut log is( matcher )", 
+	"Alias of ut log output. Kept for backwards compatibility."
 );

--- a/Source/Matchers/Messages.jsl
+++ b/Source/Matchers/Messages.jsl
@@ -50,14 +50,14 @@ Define Class("UtMessageMatcher",
 		matcher - any object
 */
 ut matcher factory( 
-  "ut message",
-  Expr(Function( {matcher, description, message},
-    {obj},
-    obj = New Object( UtMessageMatcher( ut ensure matcher( Name Expr( matcher ) ), description, message ) );
-    obj:self = obj;
-  )),
-  "ut message( matcher, description, message )",
-  "General message matcher factory. Mostly used in other factory functions, but can be used in tests if needed."
+	"ut message",
+	Expr(Function( {matcher, description, message},
+		{obj},
+		obj = New Object( UtMessageMatcher( ut ensure matcher( Name Expr( matcher ) ), description, message ) );
+		obj:self = obj;
+	)),
+	"ut message( matcher, description, message )",
+	"General message matcher factory. Mostly used in other factory functions, but can be used in tests if needed."
 );
 
 /* 
@@ -79,13 +79,13 @@ ut matcher factory(
 		---------
 */
 ut matcher factory( 
-  "ut title",
-  Expr(Function( {matcher},
-    ut message( Name Expr( matcher ), "title", "Get Title" );
-  )),
-  "ut title( matcher )",
-  "Compare inner matcher to the result of sending the Get Title message to the result.",
-  {{"Simple", pb = Panel Box( "hello, world" ); ut assert that( Expr( pb ), ut title( "hello, world" ) );}}
+	"ut title",
+	Expr(Function( {matcher},
+		ut message( Name Expr( matcher ), "title", "Get Title" );
+	)),
+	"ut title( matcher )",
+	"Compare inner matcher to the result of sending the Get Title message to the result.",
+	{{"Simple", pb = Panel Box( "hello, world" ); ut assert that( Expr( pb ), ut title( "hello, world" ) );}}
 );
 
 /* 
@@ -107,13 +107,13 @@ ut matcher factory(
 		---------
 */
 ut matcher factory( 
-  "ut text",
-  Expr(Function( {matcher},
-    ut message( Name Expr( matcher ), "text", "Get Text" );
-  )),
-  "ut text( matcher )",
-  "Compare inner matcher to the result of sending the Get Text message to the result.",
-  {{"Simple", tb = Text Box( "hello, world" );ut assert that( Expr( tb ), ut text( "hello, world" ) ); }}
+	"ut text",
+	Expr(Function( {matcher},
+		ut message( Name Expr( matcher ), "text", "Get Text" );
+	)),
+	"ut text( matcher )",
+	"Compare inner matcher to the result of sending the Get Text message to the result.",
+	{{"Simple", tb = Text Box( "hello, world" );ut assert that( Expr( tb ), ut text( "hello, world" ) ); }}
 );
 
 /* 	Function: ut enabled
@@ -138,18 +138,18 @@ ut matcher factory(
 		---------
 */
 ut matcher factory( "ut enabled",
-  Expr(Function( {matcher},
-    ut message( Name Expr( matcher ), "enabled", "Get Enabled" );
-  )),
-  "ut enabled( matcher )",
-  "Compare inner matcher to the result of sending the Get Enabled message to the result. This message checks the enabled state set by the Enabled message and not the Enable message.",
-  {{
-    "Simple", 
-    tb = Text Box( "hello, world" );
+	Expr(Function( {matcher},
+		ut message( Name Expr( matcher ), "enabled", "Get Enabled" );
+	)),
+	"ut enabled( matcher )",
+	"Compare inner matcher to the result of sending the Get Enabled message to the result. This message checks the enabled state set by the Enabled message and not the Enable message.",
+	{{
+		"Simple", 
+		tb = Text Box( "hello, world" );
 		ut assert that( Expr( tb ), ut enabled( 1 ) );
 		tb << Enabled( 0 );
 		ut assert that( Expr( tb ), ut enabled( 0 ) );
-  }}
+	}}
 );
 
 /* 
@@ -171,13 +171,13 @@ ut matcher factory( "ut enabled",
 		---------
 */
 ut matcher factory( 
-  "ut class name", 
-  Expr(Function( {matcher},
-    ut message( Name Expr( matcher ), "class name", "Class Name" );
-  )),
-  "ut class name( matcher )",
-  "Compare inner matcher to the result of sending the Class Name message to the result.",
-  {{"Simple", pb = Panel Box( "hello, world" ); ut assert that( Expr( pb ), ut class name( "PanelBox" ) ); }}
+	"ut class name", 
+	Expr(Function( {matcher},
+		ut message( Name Expr( matcher ), "class name", "Class Name" );
+	)),
+	"ut class name( matcher )",
+	"Compare inner matcher to the result of sending the Class Name message to the result.",
+	{{"Simple", pb = Panel Box( "hello, world" ); ut assert that( Expr( pb ), ut class name( "PanelBox" ) ); }}
 );
 
 /* 
@@ -204,18 +204,18 @@ ut matcher factory(
 		---------
 */
 ut matcher factory( 
-  "ut name", 
-  Expr(Function( {matcher},
-    ut message( Name Expr( matcher ), "name", "Get Name" );
-  )),
-  "ut name( matcher )",
-  "Compare inner matcher to the result of sending the Get Name message to the result.",
-  {{
-    "Simple",
-    dt = Open( "$SAMPLE_DATA\Big Class.jmp" );
+	"ut name", 
+	Expr(Function( {matcher},
+		ut message( Name Expr( matcher ), "name", "Get Name" );
+	)),
+	"ut name( matcher )",
+	"Compare inner matcher to the result of sending the Get Name message to the result.",
+	{{
+		"Simple",
+		dt = Open( "$SAMPLE_DATA\Big Class.jmp" );
 		ut assert that( Expr( dt ), ut name( ut host table name( "Big Class" ) ) );
 		
 		ns = New Namespace( "Foo" );
 		ut assert that( Expr( ns ), ut name( "Foo" ) );
-  }}
+	}}
 );

--- a/Source/Matchers/Messages.jsl
+++ b/Source/Matchers/Messages.jsl
@@ -49,11 +49,15 @@ Define Class("UtMessageMatcher",
 	Arguments:
 		matcher - any object
 */
-ut matcher factory( "ut message" );
-ut message = Function( {matcher, description, message},
-	{obj},
-	obj = New Object( UtMessageMatcher( ut ensure matcher( Name Expr( matcher ) ), description, message ) );
-	obj:self = obj;
+ut matcher factory( 
+  "ut message",
+  Expr(Function( {matcher, description, message},
+    {obj},
+    obj = New Object( UtMessageMatcher( ut ensure matcher( Name Expr( matcher ) ), description, message ) );
+    obj:self = obj;
+  )),
+  "ut message( matcher, description, message )",
+  "General message matcher factory. Mostly used in other factory functions, but can be used in tests if needed."
 );
 
 /* 
@@ -74,9 +78,14 @@ ut message = Function( {matcher, description, message},
 		ut assert that( Expr( pb ), ut title( "hello, world" ) );
 		---------
 */
-ut matcher factory( "ut title" );
-ut title = Function( {matcher},
-	ut message( Name Expr( matcher ), "title", "Get Title" );
+ut matcher factory( 
+  "ut title",
+  Expr(Function( {matcher},
+    ut message( Name Expr( matcher ), "title", "Get Title" );
+  )),
+  "ut title( matcher )",
+  "Compare inner matcher to the result of sending the Get Title message to the result.",
+  {{"Simple", pb = Panel Box( "hello, world" ); ut assert that( Expr( pb ), ut title( "hello, world" ) );}}
 );
 
 /* 
@@ -97,9 +106,14 @@ ut title = Function( {matcher},
 		ut assert that( Expr( tb ), ut text( "hello, world" ) );
 		---------
 */
-ut matcher factory( "ut text" );
-ut text = Function( {matcher},
-	ut message( Name Expr( matcher ), "text", "Get Text" );
+ut matcher factory( 
+  "ut text",
+  Expr(Function( {matcher},
+    ut message( Name Expr( matcher ), "text", "Get Text" );
+  )),
+  "ut text( matcher )",
+  "Compare inner matcher to the result of sending the Get Text message to the result.",
+  {{"Simple", tb = Text Box( "hello, world" );ut assert that( Expr( tb ), ut text( "hello, world" ) ); }}
 );
 
 /* 	Function: ut enabled
@@ -123,9 +137,19 @@ ut text = Function( {matcher},
 		ut assert that( Expr( tb ), ut enabled( 0 ) );
 		---------
 */
-ut matcher factory( "ut enabled" );
-ut enabled = Function( {matcher},
-	ut message( Name Expr( matcher ), "enabled", "Get Enabled" );
+ut matcher factory( "ut enabled",
+  Expr(Function( {matcher},
+    ut message( Name Expr( matcher ), "enabled", "Get Enabled" );
+  )),
+  "ut enabled( matcher )",
+  "Compare inner matcher to the result of sending the Get Enabled message to the result. This message checks the enabled state set by the Enabled message and not the Enable message.",
+  {{
+    "Simple", 
+    tb = Text Box( "hello, world" );
+		ut assert that( Expr( tb ), ut enabled( 1 ) );
+		tb << Enabled( 0 );
+		ut assert that( Expr( tb ), ut enabled( 0 ) );
+  }}
 );
 
 /* 
@@ -146,9 +170,14 @@ ut enabled = Function( {matcher},
 		ut assert that( Expr( pb ), ut class name( "PanelBox" ) );
 		---------
 */
-ut matcher factory( "ut class name" );
-ut class name = Function( {matcher},
-	ut message( Name Expr( matcher ), "class name", "Class Name" );
+ut matcher factory( 
+  "ut class name", 
+  Expr(Function( {matcher},
+    ut message( Name Expr( matcher ), "class name", "Class Name" );
+  )),
+  "ut class name( matcher )",
+  "Compare inner matcher to the result of sending the Class Name message to the result.",
+  {{"Simple", pb = Panel Box( "hello, world" ); ut assert that( Expr( pb ), ut class name( "PanelBox" ) ); }}
 );
 
 /* 
@@ -174,7 +203,19 @@ ut class name = Function( {matcher},
 		ut assert that( Expr( ns ), ut name( "Foo" ) );
 		---------
 */
-ut matcher factory( "ut name" );
-ut name = Function( {matcher},
-	ut message( Name Expr( matcher ), "name", "Get Name" );
+ut matcher factory( 
+  "ut name", 
+  Expr(Function( {matcher},
+    ut message( Name Expr( matcher ), "name", "Get Name" );
+  )),
+  "ut name( matcher )",
+  "Compare inner matcher to the result of sending the Get Name message to the result.",
+  {{
+    "Simple",
+    dt = Open( "$SAMPLE_DATA\Big Class.jmp" );
+		ut assert that( Expr( dt ), ut name( ut host table name( "Big Class" ) ) );
+		
+		ns = New Namespace( "Foo" );
+		ut assert that( Expr( ns ), ut name( "Foo" ) );
+  }}
 );

--- a/Source/Matchers/Missing.jsl
+++ b/Source/Matchers/Missing.jsl
@@ -41,11 +41,11 @@ Define Class(
 		> ut assert that( Expr( 5 + . ), ut missing() );
 */
 ut matcher factory( 
-  "ut missing",
-  Expr(Function( {},
-    New Object( UtMissingMatcher() );
-  )),
-  "ut missing()",
-  "Use when expected value should be missing (a dot! see ut is numeric missing).",
-  {{"Simple", ut assert that( Expr( 5 + . ), ut missing() ); }}
+	"ut missing",
+	Expr(Function( {},
+		New Object( UtMissingMatcher() );
+	)),
+	"ut missing()",
+	"Use when expected value should be missing (a dot! see ut is numeric missing).",
+	{{"Simple", ut assert that( Expr( 5 + . ), ut missing() ); }}
 );

--- a/Source/Matchers/Missing.jsl
+++ b/Source/Matchers/Missing.jsl
@@ -40,7 +40,12 @@ Define Class(
 	Example:
 		> ut assert that( Expr( 5 + . ), ut missing() );
 */
-ut matcher factory( "ut missing" );
-ut missing = Function( {},
-	New Object( UtMissingMatcher() );
+ut matcher factory( 
+  "ut missing",
+  Expr(Function( {},
+    New Object( UtMissingMatcher() );
+  )),
+  "ut missing()",
+  "Use when expected value should be missing (a dot! see ut is numeric missing).",
+  {{"Simple", ut assert that( Expr( 5 + . ), ut missing() ); }}
 );

--- a/Source/Matchers/NoThrow.jsl
+++ b/Source/Matchers/NoThrow.jsl
@@ -44,11 +44,11 @@ Define Class(
 		> ut assert that( Expr( 5 + 5 ), ut no throw() );
 */
 ut matcher factory(
-  "ut no throw",
-  Expr(Function( {},
-    New Object( UtNoThrowMatcher() )
-  )),
-  "ut no throw()",
-  "Returns success if evaluated test expr does not throw. This is often unnecessary since an unexpected throw is treated as an failure. However, this can be useful if you specifically want to test that there is no throw and don't care about the result.",
-  {{"Simple", ut assert that( Expr( 5 + 5 ), ut no throw() ); }}
+	"ut no throw",
+	Expr(Function( {},
+		New Object( UtNoThrowMatcher() )
+	)),
+	"ut no throw()",
+	"Returns success if evaluated test expr does not throw. This is often unnecessary since an unexpected throw is treated as an failure. However, this can be useful if you specifically want to test that there is no throw and don't care about the result.",
+	{{"Simple", ut assert that( Expr( 5 + 5 ), ut no throw() ); }}
 );

--- a/Source/Matchers/NoThrow.jsl
+++ b/Source/Matchers/NoThrow.jsl
@@ -41,9 +41,14 @@ Define Class(
 		Factory function for <UtNoThrowMatcher>. 
 
 	Example:
-		> ut assert that( Expr( 5 + 5 ) ), ut no throw() );
+		> ut assert that( Expr( 5 + 5 ), ut no throw() );
 */
-ut matcher factory( "ut no throw" );
-ut no throw = Function( {},
-	New Object( UtNoThrowMatcher() )
+ut matcher factory(
+  "ut no throw",
+  Expr(Function( {},
+    New Object( UtNoThrowMatcher() )
+  )),
+  "ut no throw()",
+  "Returns success if evaluated test expr does not throw. This is often unnecessary since an unexpected throw is treated as an failure. However, this can be useful if you specifically want to test that there is no throw and don't care about the result.",
+  {{"Simple", ut assert that( Expr( 5 + 5 ), ut no throw() ); }}
 );

--- a/Source/Matchers/Not.jsl
+++ b/Source/Matchers/Not.jsl
@@ -51,10 +51,10 @@ Define Class(
 		> ut assert that( Expr( 5 + 5 ), ut not( ut equal to( 11 ) ) );
 */
 ut matcher factory( "ut not",
-  Expr(Function( {matcher},
-    New Object( UtNotMatcher( ut ensure matcher( Name Expr( matcher ) )) );
-  )),
-  "ut not( matcher )",
-  "Negates the given inner matcher.",
-  {{"Simple", ut assert that( Expr( 5 + 5 ), ut not( ut equal to( 11 ) ) ); }}
+	Expr(Function( {matcher},
+		New Object( UtNotMatcher( ut ensure matcher( Name Expr( matcher ) )) );
+	)),
+	"ut not( matcher )",
+	"Negates the given inner matcher.",
+	{{"Simple", ut assert that( Expr( 5 + 5 ), ut not( ut equal to( 11 ) ) ); }}
 );

--- a/Source/Matchers/Not.jsl
+++ b/Source/Matchers/Not.jsl
@@ -50,7 +50,11 @@ Define Class(
 	Example:
 		> ut assert that( Expr( 5 + 5 ), ut not( ut equal to( 11 ) ) );
 */
-ut matcher factory( "ut not" );
-ut not = Function( {matcher},
-	New Object( UtNotMatcher( ut ensure matcher( Name Expr( matcher ) )) );
+ut matcher factory( "ut not",
+  Expr(Function( {matcher},
+    New Object( UtNotMatcher( ut ensure matcher( Name Expr( matcher ) )) );
+  )),
+  "ut not( matcher )",
+  "Negates the given inner matcher.",
+  {{"Simple", ut assert that( Expr( 5 + 5 ), ut not( ut equal to( 11 ) ) ); }}
 );

--- a/Source/Matchers/OS.jsl
+++ b/Source/Matchers/OS.jsl
@@ -58,18 +58,23 @@ Define Class(
 		---------
 		
 */
-ut matcher factory( "ut os specific" );
-ut os specific = Function( {matchers, default matcher=ut skip failing()},
-	{i},
-	matchers = ut ensure matcher list( matchers );
-	For( i = 1, i <= N Items( matchers ), i++,
-		If( matchers[i] << Get Name != "UtOSMatcher",
-				Throw( "ut os specific() requires a list of ut on os() matchers." ),
-			matchers[i] << Supports Current OS(),
-				Return( matchers[i] );
-		)
-	);
-	ut ensure matcher( default matcher );
+ut matcher factory( 
+  "ut os specific",
+  Expr(Function( {matchers, default matcher=ut skip failing()},
+    {i},
+    matchers = ut ensure matcher list( matchers );
+    For( i = 1, i <= N Items( matchers ), i++,
+      If( matchers[i] << Get Name != "UtOSMatcher",
+          Throw( "ut os specific() requires a list of ut on os() matchers." ),
+        matchers[i] << Supports Current OS(),
+          Return( matchers[i] );
+      )
+    );
+    ut ensure matcher( default matcher );
+  )),
+  "ut os specific( matchers, <default matcher> )",
+  "Function to choose matcher based on the current operating system.",
+  {{"Simple", ut assert that( Expr( 0 + 0 ), ut os specific( {ut on os( {"Windows 10", "Windows 7"}, 0 )} ) ); }}
 );
 
 /* 
@@ -94,16 +99,26 @@ ut os specific = Function( {matchers, default matcher=ut skip failing()},
 		ut assert that( Expr( 0 + 0 ), ut on os( {"Windows 10", "Windows 7"}, 0 ) );
 		---------
 */
-ut matcher factory( "ut on os" );
-ut on os = Function( {os, matcher},
-	{oses},
-	If( Is String( Name Expr( os ) ),
-			oses = Eval List( {os} ),
-		Is List( Name Expr( os ) ),
-			oses = os,
-		//else
-			Throw( "ut on os() requires an OS string or list of OS Strings as the first argument." )
-	);
-	New Object( UtOSMatcher( oses, ut ensure matcher( Name Expr( matcher ) ) ) );
+ut matcher factory( 
+  "ut on os",
+  Expr(Function( {os, matcher},
+    {oses},
+    If( Is String( Name Expr( os ) ),
+        oses = Eval List( {os} ),
+      Is List( Name Expr( os ) ),
+        oses = os,
+      //else
+        Throw( "ut on os() requires an OS string or list of OS Strings as the first argument." )
+    );
+    New Object( UtOSMatcher( oses, ut ensure matcher( Name Expr( matcher ) ) ) );
+  )),
+  "ut on os( os, matcher )",
+  "Only runs the test if on running on one of the specified operating systems. Returns a success if not running on a listed OS. OS is determined by `JMP Host Information()[1]` value.",
+  {{
+    "Simple",
+    "\[
+// only run on Windows 10 or Windows 7
+ut assert that( Expr( 0 + 0 ), ut on os( {"Windows 10", "Windows 7"}, 0 ) );
+]\"
+  }}
 );
-

--- a/Source/Matchers/OS.jsl
+++ b/Source/Matchers/OS.jsl
@@ -59,22 +59,22 @@ Define Class(
 		
 */
 ut matcher factory( 
-  "ut os specific",
-  Expr(Function( {matchers, default matcher=ut skip failing()},
-    {i},
-    matchers = ut ensure matcher list( matchers );
-    For( i = 1, i <= N Items( matchers ), i++,
-      If( matchers[i] << Get Name != "UtOSMatcher",
-          Throw( "ut os specific() requires a list of ut on os() matchers." ),
-        matchers[i] << Supports Current OS(),
-          Return( matchers[i] );
-      )
-    );
-    ut ensure matcher( default matcher );
-  )),
-  "ut os specific( matchers, <default matcher> )",
-  "Function to choose matcher based on the current operating system.",
-  {{"Simple", ut assert that( Expr( 0 + 0 ), ut os specific( {ut on os( {"Windows 10", "Windows 7"}, 0 )} ) ); }}
+	"ut os specific",
+	Expr(Function( {matchers, default matcher=ut skip failing()},
+		{i},
+		matchers = ut ensure matcher list( matchers );
+		For( i = 1, i <= N Items( matchers ), i++,
+			If( matchers[i] << Get Name != "UtOSMatcher",
+					Throw( "ut os specific() requires a list of ut on os() matchers." ),
+				matchers[i] << Supports Current OS(),
+					Return( matchers[i] );
+			)
+		);
+		ut ensure matcher( default matcher );
+	)),
+	"ut os specific( matchers, <default matcher> )",
+	"Function to choose matcher based on the current operating system.",
+	{{"Simple", ut assert that( Expr( 0 + 0 ), ut os specific( {ut on os( {"Windows 10", "Windows 7"}, 0 )} ) ); }}
 );
 
 /* 
@@ -100,25 +100,25 @@ ut matcher factory(
 		---------
 */
 ut matcher factory( 
-  "ut on os",
-  Expr(Function( {os, matcher},
-    {oses},
-    If( Is String( Name Expr( os ) ),
-        oses = Eval List( {os} ),
-      Is List( Name Expr( os ) ),
-        oses = os,
-      //else
-        Throw( "ut on os() requires an OS string or list of OS Strings as the first argument." )
-    );
-    New Object( UtOSMatcher( oses, ut ensure matcher( Name Expr( matcher ) ) ) );
-  )),
-  "ut on os( os, matcher )",
-  "Only runs the test if on running on one of the specified operating systems. Returns a success if not running on a listed OS. OS is determined by `JMP Host Information()[1]` value.",
-  {{
-    "Simple",
-    "\[
+	"ut on os",
+	Expr(Function( {os, matcher},
+		{oses},
+		If( Is String( Name Expr( os ) ),
+				oses = Eval List( {os} ),
+			Is List( Name Expr( os ) ),
+				oses = os,
+			//else
+				Throw( "ut on os() requires an OS string or list of OS Strings as the first argument." )
+		);
+		New Object( UtOSMatcher( oses, ut ensure matcher( Name Expr( matcher ) ) ) );
+	)),
+	"ut on os( os, matcher )",
+	"Only runs the test if on running on one of the specified operating systems. Returns a success if not running on a listed OS. OS is determined by `JMP Host Information()[1]` value.",
+	{{
+		"Simple",
+		"\[
 // only run on Windows 10 or Windows 7
 ut assert that( Expr( 0 + 0 ), ut on os( {"Windows 10", "Windows 7"}, 0 ) );
 ]\"
-  }}
+	}}
 );

--- a/Source/Matchers/OrderingComparison.jsl
+++ b/Source/Matchers/OrderingComparison.jsl
@@ -58,9 +58,13 @@ Define Class(
 	Example:
 		> ut assert that( Expr( 5 + 5 ), ut less than( 11 ) );
 */
-ut matcher factory( "ut less than" );
-ut less than = Function( {val},
-	New Object( UtOrderingComparisonMatcher( val, "Less", "less than" ) )
+ut matcher factory( "ut less than",
+  Expr(Function( {val},
+    New Object( UtOrderingComparisonMatcher( val, "Less", "less than" ) )
+  )),
+  "ut less than( value )",
+  "",
+  {{"Simple", ut assert that( Expr( 5 + 5 ), ut less than( 11 ) ); }}
 );
 
 /*
@@ -76,9 +80,13 @@ ut less than = Function( {val},
 	Example:
 		> ut assert that( Expr( 5 + 5 ), ut less than or equal to( 10 ) );
 */
-ut matcher factory( "ut less than or equal to" );
-ut less than or equal to = Function( {val},
-	New Object( UtOrderingComparisonMatcher( val, "Less or Equal", "less than or equal to" ) )
+ut matcher factory( "ut less than or equal to",
+  Expr(Function( {val},
+    New Object( UtOrderingComparisonMatcher( val, "Less or Equal", "less than or equal to" ) )
+  )),
+  "ut less than or equal to( value )",
+  "",
+  {{"Simple", ut assert that( Expr( 5 + 5 ), ut less than or equal to( 10 ) ); }}
 );
 
 /*
@@ -94,9 +102,14 @@ ut less than or equal to = Function( {val},
 	Example:
 		> ut assert that( Expr( 5 + 5 ), ut greater than( 9 ) );
 */
-ut matcher factory( "ut greater than" );
-ut greater than = Function( {val},
-	New Object( UtOrderingComparisonMatcher( val, "Greater", "greater than" ) )
+ut matcher factory( 
+  "ut greater than",
+  Expr(Function( {val},
+    New Object( UtOrderingComparisonMatcher( val, "Greater", "greater than" ) )
+  )),
+  "ut greater than( value )",
+  "",
+  {{"Simple", ut assert that( Expr( 5 + 5 ), ut greater than( 9 ) ); }}
 );
 
 /*
@@ -112,7 +125,12 @@ ut greater than = Function( {val},
 	Example:
 		> ut assert that( Expr( 5 + 5 ), ut greater than or equal to( 10 ) );
 */
-ut matcher factory( "ut greater than or equal to" );
-ut greater than or equal to = Function( {val},
-	New Object( UtOrderingComparisonMatcher( val, "Greater or Equal", "greater than or equal to" ) )
+ut matcher factory( 
+  "ut greater than or equal to",
+  Expr(Function( {val},
+    New Object( UtOrderingComparisonMatcher( val, "Greater or Equal", "greater than or equal to" ) )
+  )),
+  "ut greater than or equal to( value )",
+  "",
+  {{"Simple", ut assert that( Expr( 5 + 5 ), ut greater than or equal to( 10 ) ); }}
 );

--- a/Source/Matchers/OrderingComparison.jsl
+++ b/Source/Matchers/OrderingComparison.jsl
@@ -59,12 +59,12 @@ Define Class(
 		> ut assert that( Expr( 5 + 5 ), ut less than( 11 ) );
 */
 ut matcher factory( "ut less than",
-  Expr(Function( {val},
-    New Object( UtOrderingComparisonMatcher( val, "Less", "less than" ) )
-  )),
-  "ut less than( value )",
-  "",
-  {{"Simple", ut assert that( Expr( 5 + 5 ), ut less than( 11 ) ); }}
+	Expr(Function( {val},
+		New Object( UtOrderingComparisonMatcher( val, "Less", "less than" ) )
+	)),
+	"ut less than( value )",
+	"",
+	{{"Simple", ut assert that( Expr( 5 + 5 ), ut less than( 11 ) ); }}
 );
 
 /*
@@ -81,12 +81,12 @@ ut matcher factory( "ut less than",
 		> ut assert that( Expr( 5 + 5 ), ut less than or equal to( 10 ) );
 */
 ut matcher factory( "ut less than or equal to",
-  Expr(Function( {val},
-    New Object( UtOrderingComparisonMatcher( val, "Less or Equal", "less than or equal to" ) )
-  )),
-  "ut less than or equal to( value )",
-  "",
-  {{"Simple", ut assert that( Expr( 5 + 5 ), ut less than or equal to( 10 ) ); }}
+	Expr(Function( {val},
+		New Object( UtOrderingComparisonMatcher( val, "Less or Equal", "less than or equal to" ) )
+	)),
+	"ut less than or equal to( value )",
+	"",
+	{{"Simple", ut assert that( Expr( 5 + 5 ), ut less than or equal to( 10 ) ); }}
 );
 
 /*
@@ -103,13 +103,13 @@ ut matcher factory( "ut less than or equal to",
 		> ut assert that( Expr( 5 + 5 ), ut greater than( 9 ) );
 */
 ut matcher factory( 
-  "ut greater than",
-  Expr(Function( {val},
-    New Object( UtOrderingComparisonMatcher( val, "Greater", "greater than" ) )
-  )),
-  "ut greater than( value )",
-  "",
-  {{"Simple", ut assert that( Expr( 5 + 5 ), ut greater than( 9 ) ); }}
+	"ut greater than",
+	Expr(Function( {val},
+		New Object( UtOrderingComparisonMatcher( val, "Greater", "greater than" ) )
+	)),
+	"ut greater than( value )",
+	"",
+	{{"Simple", ut assert that( Expr( 5 + 5 ), ut greater than( 9 ) ); }}
 );
 
 /*
@@ -126,11 +126,11 @@ ut matcher factory(
 		> ut assert that( Expr( 5 + 5 ), ut greater than or equal to( 10 ) );
 */
 ut matcher factory( 
-  "ut greater than or equal to",
-  Expr(Function( {val},
-    New Object( UtOrderingComparisonMatcher( val, "Greater or Equal", "greater than or equal to" ) )
-  )),
-  "ut greater than or equal to( value )",
-  "",
-  {{"Simple", ut assert that( Expr( 5 + 5 ), ut greater than or equal to( 10 ) ); }}
+	"ut greater than or equal to",
+	Expr(Function( {val},
+		New Object( UtOrderingComparisonMatcher( val, "Greater or Equal", "greater than or equal to" ) )
+	)),
+	"ut greater than or equal to( value )",
+	"",
+	{{"Simple", ut assert that( Expr( 5 + 5 ), ut greater than or equal to( 10 ) ); }}
 );

--- a/Source/Matchers/Parse.jsl
+++ b/Source/Matchers/Parse.jsl
@@ -129,11 +129,15 @@ ut parsed = Function( {matcher},
 		ut assert that( ut as expr( "x == ." ), ut parse error( ut starts with( "Comparisons with missing must be done with the isMissing() function" ) ) );
 		---------
 */
-ut matcher factory( "ut parse error" );
-ut parse error = Function( {matcher},
-	New Object( UtParseErrorMatcher( ut ensure matcher( Name Expr( matcher ) ) ) );
+ut matcher factory( 
+  "ut parse error",
+  Expr(Function( {matcher},
+    New Object( UtParseErrorMatcher( ut ensure matcher( Name Expr( matcher ) ) ) );
+  )),
+  "ut parse error( matcher )",
+  "Checks that a given string throws an error when parsed.",
+  {{"Simple", ut assert that( ut as expr( "x == ." ), ut parse error( ut starts with( "Comparisons with missing must be done with the isMissing() function" ) ) ); }}
 );
-
 
 /* 
 	Function: ut no parse error
@@ -149,7 +153,12 @@ ut parse error = Function( {matcher},
 		ut assert that( ut as expr( "x = 5;" ), ut no parse error() );
 		---------
 */
-ut matcher factory( "ut no parse error" );
-ut no parse error = Function( {},
-	New Object( UtNoParseErrorMatcher() );
+ut matcher factory( 
+  "ut no parse error",
+  Expr(Function( {},
+    New Object( UtNoParseErrorMatcher() );
+  )),
+  "ut no parse error()",
+  "Checks that a given string parses successfully.",
+  {{"Simple", ut assert that( ut as expr( "x = 5;" ), ut no parse error() );}}
 );

--- a/Source/Matchers/Parse.jsl
+++ b/Source/Matchers/Parse.jsl
@@ -130,13 +130,13 @@ ut parsed = Function( {matcher},
 		---------
 */
 ut matcher factory( 
-  "ut parse error",
-  Expr(Function( {matcher},
-    New Object( UtParseErrorMatcher( ut ensure matcher( Name Expr( matcher ) ) ) );
-  )),
-  "ut parse error( matcher )",
-  "Checks that a given string throws an error when parsed.",
-  {{"Simple", ut assert that( ut as expr( "x == ." ), ut parse error( ut starts with( "Comparisons with missing must be done with the isMissing() function" ) ) ); }}
+	"ut parse error",
+	Expr(Function( {matcher},
+		New Object( UtParseErrorMatcher( ut ensure matcher( Name Expr( matcher ) ) ) );
+	)),
+	"ut parse error( matcher )",
+	"Checks that a given string throws an error when parsed.",
+	{{"Simple", ut assert that( ut as expr( "x == ." ), ut parse error( ut starts with( "Comparisons with missing must be done with the isMissing() function" ) ) ); }}
 );
 
 /* 
@@ -154,11 +154,11 @@ ut matcher factory(
 		---------
 */
 ut matcher factory( 
-  "ut no parse error",
-  Expr(Function( {},
-    New Object( UtNoParseErrorMatcher() );
-  )),
-  "ut no parse error()",
-  "Checks that a given string parses successfully.",
-  {{"Simple", ut assert that( ut as expr( "x = 5;" ), ut no parse error() );}}
+	"ut no parse error",
+	Expr(Function( {},
+		New Object( UtNoParseErrorMatcher() );
+	)),
+	"ut no parse error()",
+	"Checks that a given string parses successfully.",
+	{{"Simple", ut assert that( ut as expr( "x = 5;" ), ut no parse error() );}}
 );

--- a/Source/Matchers/Partial.jsl
+++ b/Source/Matchers/Partial.jsl
@@ -64,12 +64,20 @@ Define Class(
 		> ut assert that( Expr( {1, 2, 3} ), ut starts with( {1,2} ) );
 		> ut assert that( Expr( "Test" || "string" ), ut starts with( "Tests" ) );
 */
-ut matcher factory( "ut starts with" );
-ut starts with = Function( {val},
-	{obj},
-	obj = New Object( UtPartialMatcher( "Starts With", "starts with" ) );
-	obj:value = Name Expr( val );
-	obj;
+ut matcher factory( "ut starts with",
+  Expr(Function( {val},
+    {obj},
+    obj = New Object( UtPartialMatcher( "Starts With", "starts with" ) );
+    obj:value = Name Expr( val );
+    obj;
+  )),
+  "ut starts with( value )",
+  "Asserts using the Starts With() built-in function.",
+  {{
+    "Simple",
+    ut assert that( Expr( {1, 2, 3} ), ut starts with( {1,2} ) );
+		ut assert that( Expr( "Test" || "string" ), ut starts with( "Tests" ) );
+  }}
 );
 
 /*
@@ -89,10 +97,19 @@ ut starts with = Function( {val},
 		> ut assert that( Expr( {1, 2, 3} ), ut ends with( 3 ) );
 		> ut assert that( Expr( "Test" || "string" ), ut ends with( "tstring" ) );
 */
-ut matcher factory( "ut ends with" );
-ut ends with = Function( {val},
-	{obj},
-	obj = New Object( UtPartialMatcher( "Ends With", "ends with" ) );
-	obj:value = Name Expr( val );
-	obj;
+ut matcher factory( "ut ends with",
+  Expr(Function( {val},
+    {obj},
+    obj = New Object( UtPartialMatcher( "Ends With", "ends with" ) );
+    obj:value = Name Expr( val );
+    obj;
+  )),
+  "ut ends with( value )",
+  "Asserts using the Ends With() built-in function.",
+  {{
+    "Simple",
+    ut assert that( Expr( {1, 2, 3} ), ut ends with( {2,3} ) );
+		ut assert that( Expr( {1, 2, 3} ), ut ends with( 3 ) );
+		ut assert that( Expr( "Test" || "string" ), ut ends with( "tstring" ) );
+  }}
 );

--- a/Source/Matchers/Partial.jsl
+++ b/Source/Matchers/Partial.jsl
@@ -65,19 +65,19 @@ Define Class(
 		> ut assert that( Expr( "Test" || "string" ), ut starts with( "Tests" ) );
 */
 ut matcher factory( "ut starts with",
-  Expr(Function( {val},
-    {obj},
-    obj = New Object( UtPartialMatcher( "Starts With", "starts with" ) );
-    obj:value = Name Expr( val );
-    obj;
-  )),
-  "ut starts with( value )",
-  "Asserts using the Starts With() built-in function.",
-  {{
-    "Simple",
-    ut assert that( Expr( {1, 2, 3} ), ut starts with( {1,2} ) );
+	Expr(Function( {val},
+		{obj},
+		obj = New Object( UtPartialMatcher( "Starts With", "starts with" ) );
+		obj:value = Name Expr( val );
+		obj;
+	)),
+	"ut starts with( value )",
+	"Asserts using the Starts With() built-in function.",
+	{{
+		"Simple",
+		ut assert that( Expr( {1, 2, 3} ), ut starts with( {1,2} ) );
 		ut assert that( Expr( "Test" || "string" ), ut starts with( "Tests" ) );
-  }}
+	}}
 );
 
 /*
@@ -98,18 +98,18 @@ ut matcher factory( "ut starts with",
 		> ut assert that( Expr( "Test" || "string" ), ut ends with( "tstring" ) );
 */
 ut matcher factory( "ut ends with",
-  Expr(Function( {val},
-    {obj},
-    obj = New Object( UtPartialMatcher( "Ends With", "ends with" ) );
-    obj:value = Name Expr( val );
-    obj;
-  )),
-  "ut ends with( value )",
-  "Asserts using the Ends With() built-in function.",
-  {{
-    "Simple",
-    ut assert that( Expr( {1, 2, 3} ), ut ends with( {2,3} ) );
+	Expr(Function( {val},
+		{obj},
+		obj = New Object( UtPartialMatcher( "Ends With", "ends with" ) );
+		obj:value = Name Expr( val );
+		obj;
+	)),
+	"ut ends with( value )",
+	"Asserts using the Ends With() built-in function.",
+	{{
+		"Simple",
+		ut assert that( Expr( {1, 2, 3} ), ut ends with( {2,3} ) );
 		ut assert that( Expr( {1, 2, 3} ), ut ends with( 3 ) );
 		ut assert that( Expr( "Test" || "string" ), ut ends with( "tstring" ) );
-  }}
+	}}
 );

--- a/Source/Matchers/Size.jsl
+++ b/Source/Matchers/Size.jsl
@@ -110,7 +110,12 @@ ut matcher factory(
 	)),
 	"ut n cols( matcher )",
 	"Passes the N Cols() of the actual value to the inner matcher.",
-	{{"Simple", ut assert that( Expr( dt ), ut n cols( 3 ) ); ut assert that( Expr( Transpose( 1::3 ) ), ut n cols( 1 ) ); }}
+	{{
+		"Simple", 
+		dt = Open( "$SAMPLE_DATA\Big Class.jmp" );
+		ut assert that( Expr( dt ), ut n cols( 5 ) ); 
+		ut assert that( Expr( Transpose( 1::3 ) ), ut n cols( 1 ) );
+	}}
 );
 
 /* 
@@ -136,5 +141,10 @@ ut matcher factory(
 	)),
 	"ut n rows( matcher )",
 	"Passes the N Rows() of the actual value to the inner matcher.",
-	{{"Simple", ut assert that( Expr( dt ), ut n rows( 3 ) ); ut assert that( Expr( Transpose( 1::3 ) ), ut n rows( 3 ) ); }}
+	{{
+		"Simple", 
+		dt = Open( "$SAMPLE_DATA\Big Class.jmp" );
+		ut assert that( Expr( dt ), ut n rows( 40 ) ); 
+		ut assert that( Expr( Transpose( 1::3 ) ), ut n rows( 3 ) );
+	}}
 );

--- a/Source/Matchers/Size.jsl
+++ b/Source/Matchers/Size.jsl
@@ -54,12 +54,12 @@ Define Class(
 		> ut assert that( Expr( "str" || "ing" ), ut length( 6 ) );
 */
 ut matcher factory( "ut length",
-  Expr(Function( {matcher},
-    New Object( UtSizeMatcher( ut ensure matcher( Name Expr( matcher ) ), "Length", "length" ) )
-  )),
-  "ut length( matcher )",
-  "Passes the Length() of the actual value to the inner matcher.",
-  {{"Simple", ut assert that( Expr( {1,2,3} ), ut length( 3 ) ); ut assert that( Expr( "str" || "ing" ), ut length( 6 ) ); }}
+	Expr(Function( {matcher},
+		New Object( UtSizeMatcher( ut ensure matcher( Name Expr( matcher ) ), "Length", "length" ) )
+	)),
+	"ut length( matcher )",
+	"Passes the Length() of the actual value to the inner matcher.",
+	{{"Simple", ut assert that( Expr( {1,2,3} ), ut length( 3 ) ); ut assert that( Expr( "str" || "ing" ), ut length( 6 ) ); }}
 );
 
 /* 
@@ -78,13 +78,13 @@ ut matcher factory( "ut length",
 		> ut assert that( Expr( {1,2,3} ), ut n items( 3 ) );
 */
 ut matcher factory( 
-  "ut n items",
-  Expr(Function( {matcher},
-    New Object( UtSizeMatcher( ut ensure matcher( Name Expr( matcher ) ), "N Items", "n items" ) )
-  )),
-  "ut n items( matcher )",
-  "Passes the N Items() of the actual value to the inner matcher.",
-  {{"Simple", ut assert that( Expr( {1,2,3} ), ut n items( 3 ) ); }}
+	"ut n items",
+	Expr(Function( {matcher},
+		New Object( UtSizeMatcher( ut ensure matcher( Name Expr( matcher ) ), "N Items", "n items" ) )
+	)),
+	"ut n items( matcher )",
+	"Passes the N Items() of the actual value to the inner matcher.",
+	{{"Simple", ut assert that( Expr( {1,2,3} ), ut n items( 3 ) ); }}
 );
 
 /* 
@@ -104,13 +104,13 @@ ut matcher factory(
 		> ut assert that( Expr( Transpose( 1::3 ) ), ut n cols( 1 ) );
 */
 ut matcher factory( 
-  "ut n cols",
-  Expr(Function( {matcher},
-    New Object( UtSizeMatcher( ut ensure matcher( Name Expr( matcher ) ), "N Cols", "n cols" ) )
-  )),
-  "ut n cols( matcher )",
-  "Passes the N Cols() of the actual value to the inner matcher.",
-  {{"Simple", ut assert that( Expr( dt ), ut n cols( 3 ) ); ut assert that( Expr( Transpose( 1::3 ) ), ut n cols( 1 ) ); }}
+	"ut n cols",
+	Expr(Function( {matcher},
+		New Object( UtSizeMatcher( ut ensure matcher( Name Expr( matcher ) ), "N Cols", "n cols" ) )
+	)),
+	"ut n cols( matcher )",
+	"Passes the N Cols() of the actual value to the inner matcher.",
+	{{"Simple", ut assert that( Expr( dt ), ut n cols( 3 ) ); ut assert that( Expr( Transpose( 1::3 ) ), ut n cols( 1 ) ); }}
 );
 
 /* 
@@ -130,11 +130,11 @@ ut matcher factory(
 		> ut assert that( Expr( Transpose( 1::3 ) ), ut n rows( 3 ) );
 */
 ut matcher factory( 
-  "ut n rows",
-  Expr(Function( {matcher},
-    New Object( UtSizeMatcher( ut ensure matcher( Name Expr( matcher ) ), "N Rows", "n rows" ) )
-  )),
-  "ut n rows( matcher )",
-  "Passes the N Rows() of the actual value to the inner matcher.",
-  {{"Simple", ut assert that( Expr( dt ), ut n rows( 3 ) ); ut assert that( Expr( Transpose( 1::3 ) ), ut n rows( 3 ) ); }}
+	"ut n rows",
+	Expr(Function( {matcher},
+		New Object( UtSizeMatcher( ut ensure matcher( Name Expr( matcher ) ), "N Rows", "n rows" ) )
+	)),
+	"ut n rows( matcher )",
+	"Passes the N Rows() of the actual value to the inner matcher.",
+	{{"Simple", ut assert that( Expr( dt ), ut n rows( 3 ) ); ut assert that( Expr( Transpose( 1::3 ) ), ut n rows( 3 ) ); }}
 );

--- a/Source/Matchers/Size.jsl
+++ b/Source/Matchers/Size.jsl
@@ -53,9 +53,13 @@ Define Class(
 		> ut assert that( Expr( {1,2,3} ), ut length( 3 ) );
 		> ut assert that( Expr( "str" || "ing" ), ut length( 6 ) );
 */
-ut matcher factory( "ut length" );
-ut length = Function( {matcher},
-	New Object( UtSizeMatcher( ut ensure matcher( Name Expr( matcher ) ), "Length", "length" ) )
+ut matcher factory( "ut length",
+  Expr(Function( {matcher},
+    New Object( UtSizeMatcher( ut ensure matcher( Name Expr( matcher ) ), "Length", "length" ) )
+  )),
+  "ut length( matcher )",
+  "Passes the Length() of the actual value to the inner matcher.",
+  {{"Simple", ut assert that( Expr( {1,2,3} ), ut length( 3 ) ); ut assert that( Expr( "str" || "ing" ), ut length( 6 ) ); }}
 );
 
 /* 
@@ -73,9 +77,14 @@ ut length = Function( {matcher},
 	Examples:
 		> ut assert that( Expr( {1,2,3} ), ut n items( 3 ) );
 */
-ut matcher factory( "ut n items" );
-ut n items = Function( {matcher},
-	New Object( UtSizeMatcher( ut ensure matcher( Name Expr( matcher ) ), "N Items", "n items" ) )
+ut matcher factory( 
+  "ut n items",
+  Expr(Function( {matcher},
+    New Object( UtSizeMatcher( ut ensure matcher( Name Expr( matcher ) ), "N Items", "n items" ) )
+  )),
+  "ut n items( matcher )",
+  "Passes the N Items() of the actual value to the inner matcher.",
+  {{"Simple", ut assert that( Expr( {1,2,3} ), ut n items( 3 ) ); }}
 );
 
 /* 
@@ -94,9 +103,14 @@ ut n items = Function( {matcher},
 		> ut assert that( Expr( dt ), ut n cols( 3 ) );
 		> ut assert that( Expr( Transpose( 1::3 ) ), ut n cols( 1 ) );
 */
-ut matcher factory( "ut n cols" );
-ut n cols = Function( {matcher},
-	New Object( UtSizeMatcher( ut ensure matcher( Name Expr( matcher ) ), "N Cols", "n cols" ) )
+ut matcher factory( 
+  "ut n cols",
+  Expr(Function( {matcher},
+    New Object( UtSizeMatcher( ut ensure matcher( Name Expr( matcher ) ), "N Cols", "n cols" ) )
+  )),
+  "ut n cols( matcher )",
+  "Passes the N Cols() of the actual value to the inner matcher.",
+  {{"Simple", ut assert that( Expr( dt ), ut n cols( 3 ) ); ut assert that( Expr( Transpose( 1::3 ) ), ut n cols( 1 ) ); }}
 );
 
 /* 
@@ -115,7 +129,12 @@ ut n cols = Function( {matcher},
 		> ut assert that( Expr( dt ), ut n rows( 3 ) );
 		> ut assert that( Expr( Transpose( 1::3 ) ), ut n rows( 3 ) );
 */
-ut matcher factory( "ut n rows" );
-ut n rows = Function( {matcher},
-	New Object( UtSizeMatcher( ut ensure matcher( Name Expr( matcher ) ), "N Rows", "n rows" ) )
+ut matcher factory( 
+  "ut n rows",
+  Expr(Function( {matcher},
+    New Object( UtSizeMatcher( ut ensure matcher( Name Expr( matcher ) ), "N Rows", "n rows" ) )
+  )),
+  "ut n rows( matcher )",
+  "Passes the N Rows() of the actual value to the inner matcher.",
+  {{"Simple", ut assert that( Expr( dt ), ut n rows( 3 ) ); ut assert that( Expr( Transpose( 1::3 ) ), ut n rows( 3 ) ); }}
 );

--- a/Source/Matchers/Skip.jsl
+++ b/Source/Matchers/Skip.jsl
@@ -54,20 +54,20 @@ Define Class(
 		---------
 */
 ut matcher factory( "ut skip",
-  Expr(Function( {matcher=ut anything()},
-    New Object( UtSkipMatcher( ut ensure matcher( Name Expr( matcher ) ), 0 ) )
-  )),
-  "ut skip()",
-  "Used to mark an expression you want to skip. Instead a success is reported.",
-  {{
-    "Simple",
-    "\[
+	Expr(Function( {matcher=ut anything()},
+		New Object( UtSkipMatcher( ut ensure matcher( Name Expr( matcher ) ), 0 ) )
+	)),
+	"ut skip()",
+	"Used to mark an expression you want to skip. Instead a success is reported.",
+	{{
+		"Simple",
+		"\[
 // If you wanted to skip this assertion but leave it in the
 // script for some reason, you could prevent it running by
 // wrapping the expected value/matcher with ut skip()
 ut assert that( Expr( 1 + 1 ), ut skip( ut equal to( 2 ) ) );
 ]\"
-  }}
+	}}
 );
 
 /* 
@@ -92,19 +92,19 @@ ut assert that( Expr( 1 + 1 ), ut skip( ut equal to( 2 ) ) );
 		---------
 */
 ut matcher factory( 
-  "ut skip failing",
-  Expr(Function( {matcher=ut anything()},
-    New Object( UtSkipMatcher( ut ensure matcher( Name Expr( matcher ) ), 1, "skipped test marked failing" ) )
-  )),
-  "ut skip failing()",
-  "Used to mark an expression you want to skip. Instead a failure is reported.",
-  {{
-    "Simple",
-    "\[
+	"ut skip failing",
+	Expr(Function( {matcher=ut anything()},
+		New Object( UtSkipMatcher( ut ensure matcher( Name Expr( matcher ) ), 1, "skipped test marked failing" ) )
+	)),
+	"ut skip failing()",
+	"Used to mark an expression you want to skip. Instead a failure is reported.",
+	{{
+		"Simple",
+		"\[
 // If you wanted to skip this assertion but leave it in the
 // script failing, you could prevent it running by
 // wrapping the expected value/matcher with ut skip failing()
 ut assert that( Expr( 1 + 1 ), ut skip failing( ut equal to( 2 ) ) );
 ]\"
-  }}
+	}}
 );

--- a/Source/Matchers/Skip.jsl
+++ b/Source/Matchers/Skip.jsl
@@ -53,9 +53,21 @@ Define Class(
 		ut assert that( Expr( 1 + 1 ), ut skip( ut equal to( 2 ) ) );
 		---------
 */
-ut matcher factory( "ut skip" );
-ut skip = Function( {matcher=ut anything()},
-	New Object( UtSkipMatcher( ut ensure matcher( Name Expr( matcher ) ), 0 ) )
+ut matcher factory( "ut skip",
+  Expr(Function( {matcher=ut anything()},
+    New Object( UtSkipMatcher( ut ensure matcher( Name Expr( matcher ) ), 0 ) )
+  )),
+  "ut skip()",
+  "Used to mark an expression you want to skip. Instead a success is reported.",
+  {{
+    "Simple",
+    "\[
+// If you wanted to skip this assertion but leave it in the
+// script for some reason, you could prevent it running by
+// wrapping the expected value/matcher with ut skip()
+ut assert that( Expr( 1 + 1 ), ut skip( ut equal to( 2 ) ) );
+]\"
+  }}
 );
 
 /* 
@@ -76,10 +88,23 @@ ut skip = Function( {matcher=ut anything()},
 		// If you wanted to skip this assertion but leave it in the
 		// script for some reason, you could prevent it running by
 		// wrapping the expected value/matcher with ut skip()
-		ut assert that( Expr( 1 + 1 ), ut skip( ut equal to( 2 ) ) );
+		ut assert that( Expr( 1 + 1 ), ut skip failing( ut equal to( 2 ) ) );
 		---------
 */
-ut matcher factory( "ut skip failing" );
-ut skip failing = Function( {matcher=ut anything()},
-	New Object( UtSkipMatcher( ut ensure matcher( Name Expr( matcher ) ), 1, "skipped test marked failing" ) )
+ut matcher factory( 
+  "ut skip failing",
+  Expr(Function( {matcher=ut anything()},
+    New Object( UtSkipMatcher( ut ensure matcher( Name Expr( matcher ) ), 1, "skipped test marked failing" ) )
+  )),
+  "ut skip failing()",
+  "Used to mark an expression you want to skip. Instead a failure is reported.",
+  {{
+    "Simple",
+    "\[
+// If you wanted to skip this assertion but leave it in the
+// script failing, you could prevent it running by
+// wrapping the expected value/matcher with ut skip failing()
+ut assert that( Expr( 1 + 1 ), ut skip failing( ut equal to( 2 ) ) );
+]\"
+  }}
 );

--- a/Source/Matchers/Sorted.jsl
+++ b/Source/Matchers/Sorted.jsl
@@ -39,20 +39,20 @@ Define Class("UtSortedMatcher", Base Class(Ut Matcher),
 		---Prototype---
 		ut sorted( UtMatcher matcher )
 		---------------
-    Sorts a list before passing to inner matcher.
-    
-    Factory function for <UtSortedMatcher>.
+		Sorts a list before passing to inner matcher.
+		
+		Factory function for <UtSortedMatcher>.
 
 	Example:
 		> ut assert that( Expr( {3,2,1} ), ut sorted( {1,2,3} ) );
 */
 
 ut matcher factory( 
-  "ut sorted",
-  Expr(Function( {matcher},
-    New Object( UtSortedMatcher( ut ensure matcher( Name Expr( matcher ) ) ) );
-  )),
-  "ut sorted( matcher )",
-  "Sorts a list before passing to inner matcher.",
-  {{"Simple", ut assert that( Expr( {3,2,1} ), ut sorted( {1,2,3} ) );}}
+	"ut sorted",
+	Expr(Function( {matcher},
+		New Object( UtSortedMatcher( ut ensure matcher( Name Expr( matcher ) ) ) );
+	)),
+	"ut sorted( matcher )",
+	"Sorts a list before passing to inner matcher.",
+	{{"Simple", ut assert that( Expr( {3,2,1} ), ut sorted( {1,2,3} ) );}}
 );

--- a/Source/Matchers/Sorted.jsl
+++ b/Source/Matchers/Sorted.jsl
@@ -39,14 +39,20 @@ Define Class("UtSortedMatcher", Base Class(Ut Matcher),
 		---Prototype---
 		ut sorted( UtMatcher matcher )
 		---------------
-	
-	Factory function for <UtSortedMatcher>.
+    Sorts a list before passing to inner matcher.
+    
+    Factory function for <UtSortedMatcher>.
 
 	Example:
 		> ut assert that( Expr( {3,2,1} ), ut sorted( {1,2,3} ) );
 */
 
-ut matcher factory( "ut sorted" );
-ut sorted = Function( {matcher},
-	New Object( UtSortedMatcher( ut ensure matcher( Name Expr( matcher ) ) ) );
+ut matcher factory( 
+  "ut sorted",
+  Expr(Function( {matcher},
+    New Object( UtSortedMatcher( ut ensure matcher( Name Expr( matcher ) ) ) );
+  )),
+  "ut sorted( matcher )",
+  "Sorts a list before passing to inner matcher.",
+  {{"Simple", ut assert that( Expr( {3,2,1} ), ut sorted( {1,2,3} ) );}}
 );

--- a/Source/Matchers/StringPattern.jsl
+++ b/Source/Matchers/StringPattern.jsl
@@ -49,14 +49,14 @@ Define Class(
 		> ut assert that( Expr( "str" || "ing" ), ut contains pattern( "str.*g" ) );
 */
 ut matcher factory( 
-  "ut contains pattern",
-  Expr(Function( {val},
-    If( Is String( Name Expr( val ) ),
-      New Object( UtStringPatternMatcher( val ) ),
-      Throw( "ut contains pattern() requires a string as the pattern argument" )
-    );
-  )),
-  "ut contains patern( value )",
-  "Checks for a regex pattern within the evaluated actual expression.",
-  {{"Simple", ut assert that( Expr( "str" || "ing" ), ut contains pattern( "str.*g" ) ); }}
+	"ut contains pattern",
+	Expr(Function( {val},
+		If( Is String( Name Expr( val ) ),
+			New Object( UtStringPatternMatcher( val ) ),
+			Throw( "ut contains pattern() requires a string as the pattern argument" )
+		);
+	)),
+	"ut contains patern( value )",
+	"Checks for a regex pattern within the evaluated actual expression.",
+	{{"Simple", ut assert that( Expr( "str" || "ing" ), ut contains pattern( "str.*g" ) ); }}
 );

--- a/Source/Matchers/StringPattern.jsl
+++ b/Source/Matchers/StringPattern.jsl
@@ -48,10 +48,15 @@ Define Class(
 	Example:
 		> ut assert that( Expr( "str" || "ing" ), ut contains pattern( "str.*g" ) );
 */
-ut matcher factory( "ut contains pattern" );
-ut contains pattern = Function( {val},
-	If( Is String( Name Expr( val ) ),
-		New Object( UtStringPatternMatcher( val ) ),
-		Throw( "ut contains pattern() requires a string as the pattern argument" )
-	);
+ut matcher factory( 
+  "ut contains pattern",
+  Expr(Function( {val},
+    If( Is String( Name Expr( val ) ),
+      New Object( UtStringPatternMatcher( val ) ),
+      Throw( "ut contains pattern() requires a string as the pattern argument" )
+    );
+  )),
+  "ut contains patern( value )",
+  "Checks for a regex pattern within the evaluated actual expression.",
+  {{"Simple", ut assert that( Expr( "str" || "ing" ), ut contains pattern( "str.*g" ) ); }}
 );

--- a/Source/Matchers/Throws.jsl
+++ b/Source/Matchers/Throws.jsl
@@ -52,17 +52,17 @@ Define Class(
 		> ut assert that( Expr( Sin( "a" ) ), ut throws( ut anything() ) );
 */
 ut matcher factory( 
-  "ut throws",
-  Expr(Function( {matcher},
-    New Object( UtThrowsMatcher( ut ensure matcher( Name Expr( matcher ) ) ) )
-  )),
-  "ut throws( matcher )",
-  "Captures a thrown message from evaluating the actual expression. Inner matchers can be used to assert on the actual error message. The error message comes from the first argument in the exception_msg variable, and not from the log.",
-  {{
-    "Simple",
-    ut assert that( Expr( Sin( "a" ) ), ut throws( "Cannot convert argument to a number [or matrix]" ) );
+	"ut throws",
+	Expr(Function( {matcher},
+		New Object( UtThrowsMatcher( ut ensure matcher( Name Expr( matcher ) ) ) )
+	)),
+	"ut throws( matcher )",
+	"Captures a thrown message from evaluating the actual expression. Inner matchers can be used to assert on the actual error message. The error message comes from the first argument in the exception_msg variable, and not from the log.",
+	{{
+		"Simple",
+		ut assert that( Expr( Sin( "a" ) ), ut throws( "Cannot convert argument to a number [or matrix]" ) );
 		ut assert that( Expr( Sin( "a" ) ), ut throws( ut anything() ) );
-  }}
+	}}
 );
 
 /* 
@@ -75,12 +75,12 @@ ut matcher factory(
 		Factory function for <UtThrowsMatcher>.
 */
 ut matcher factory( 
-  "ut throws invalid arg",
-  Expr(Function({},
-    New Object( UtThrowsMatcher( ut equal to( "argument value is invalid" ) ) )
-  )),
-  "ut throws invalid arg()",
-  "\[Equivalent to ut throws( "argument value is invalid" )]\"
+	"ut throws invalid arg",
+	Expr(Function({},
+		New Object( UtThrowsMatcher( ut equal to( "argument value is invalid" ) ) )
+	)),
+	"ut throws invalid arg()",
+	"\[Equivalent to ut throws( "argument value is invalid" )]\"
 );
 
 /* 
@@ -93,12 +93,12 @@ ut matcher factory(
 		Factory function for <UtThrowsMatcher>.
 */
 ut matcher factory( 
-  "ut throws too many args",
-  Expr(Function({},
-    New Object( UtThrowsMatcher( ut equal to( "too many arguments" ) ) )
-  )),
-  "ut throws too many args()",
-  "\[Equivalent to ut throws( "too many arguments" )]\"
+	"ut throws too many args",
+	Expr(Function({},
+		New Object( UtThrowsMatcher( ut equal to( "too many arguments" ) ) )
+	)),
+	"ut throws too many args()",
+	"\[Equivalent to ut throws( "too many arguments" )]\"
 );
 
 /* 
@@ -111,11 +111,11 @@ ut matcher factory(
 		Factory function for <UtThrowsMatcher>.
 */
 ut matcher factory( 
-  "ut throws name unresolved",
-  Expr(Function({var},
-    New Object( UtThrowsMatcher( ut equal to( "Name Unresolved: " || var ) ) )
-  )),
-  "ut throws name unresolved( variable name )",
-  "\[Equivalent to ut throws( "Name Unresolved: var" )]\",
-  {{"Simple", ut assert that( Expr( someVariableThatShouldNotExist ), ut throws name unresolved("someVariableThatShouldNotExist"))}}
+	"ut throws name unresolved",
+	Expr(Function({var},
+		New Object( UtThrowsMatcher( ut equal to( "Name Unresolved: " || var ) ) )
+	)),
+	"ut throws name unresolved( variable name )",
+	"\[Equivalent to ut throws( "Name Unresolved: var" )]\",
+	{{"Simple", ut assert that( Expr( someVariableThatShouldNotExist ), ut throws name unresolved("someVariableThatShouldNotExist"))}}
 );

--- a/Source/Matchers/Throws.jsl
+++ b/Source/Matchers/Throws.jsl
@@ -51,9 +51,18 @@ Define Class(
 		> ut assert that( Expr( Sin( "a" ) ), ut throws( "Cannot convert argument to a number [or matrix]" ) );
 		> ut assert that( Expr( Sin( "a" ) ), ut throws( ut anything() ) );
 */
-ut matcher factory( "ut throws" );
-ut throws = Function( {matcher},
-	New Object( UtThrowsMatcher( ut ensure matcher( Name Expr( matcher ) ) ) )
+ut matcher factory( 
+  "ut throws",
+  Expr(Function( {matcher},
+    New Object( UtThrowsMatcher( ut ensure matcher( Name Expr( matcher ) ) ) )
+  )),
+  "ut throws( matcher )",
+  "Captures a thrown message from evaluating the actual expression. Inner matchers can be used to assert on the actual error message. The error message comes from the first argument in the exception_msg variable, and not from the log.",
+  {{
+    "Simple",
+    ut assert that( Expr( Sin( "a" ) ), ut throws( "Cannot convert argument to a number [or matrix]" ) );
+		ut assert that( Expr( Sin( "a" ) ), ut throws( ut anything() ) );
+  }}
 );
 
 /* 
@@ -65,9 +74,13 @@ ut throws = Function( {matcher},
 
 		Factory function for <UtThrowsMatcher>.
 */
-ut matcher factory( "ut throws invalid arg" );
-ut throws invalid arg = Function({},
-	New Object( UtThrowsMatcher( ut equal to( "argument value is invalid" ) ) )
+ut matcher factory( 
+  "ut throws invalid arg",
+  Expr(Function({},
+    New Object( UtThrowsMatcher( ut equal to( "argument value is invalid" ) ) )
+  )),
+  "ut throws invalid arg()",
+  "\[Equivalent to ut throws( "argument value is invalid" )]\"
 );
 
 /* 
@@ -79,9 +92,13 @@ ut throws invalid arg = Function({},
 
 		Factory function for <UtThrowsMatcher>.
 */
-ut matcher factory( "ut throws too many args" );
-ut throws too many args = Function({},
-	New Object( UtThrowsMatcher( ut equal to( "too many arguments" ) ) )
+ut matcher factory( 
+  "ut throws too many args",
+  Expr(Function({},
+    New Object( UtThrowsMatcher( ut equal to( "too many arguments" ) ) )
+  )),
+  "ut throws too many args()",
+  "\[Equivalent to ut throws( "too many arguments" )]\"
 );
 
 /* 
@@ -93,7 +110,12 @@ ut throws too many args = Function({},
 
 		Factory function for <UtThrowsMatcher>.
 */
-ut matcher factory( "ut throws name unresolved" );
-ut throws name unresolved = Function({var},
-	New Object( UtThrowsMatcher( ut equal to( "Name Unresolved: " || var ) ) )
+ut matcher factory( 
+  "ut throws name unresolved",
+  Expr(Function({var},
+    New Object( UtThrowsMatcher( ut equal to( "Name Unresolved: " || var ) ) )
+  )),
+  "ut throws name unresolved( variable name )",
+  "\[Equivalent to ut throws( "Name Unresolved: var" )]\",
+  {{"Simple", ut assert that( Expr( someVariableThatShouldNotExist ), ut throws name unresolved("someVariableThatShouldNotExist"))}}
 );

--- a/Source/Matchers/TypedAs.jsl
+++ b/Source/Matchers/TypedAs.jsl
@@ -51,7 +51,12 @@ Define Class(
 	Example:
 		> ut assert that( Expr( 5 + 5 ), ut typed as( "Number" ) );
 */
-ut matcher factory( "ut typed as" );
-ut typed as = Function( {matcher},
-	New Object( UtTypedAsMatcher( ut ensure matcher( Name Expr( matcher ) ) ) )
+ut matcher factory( 
+  "ut typed as",
+  Expr(Function( {matcher},
+    New Object( UtTypedAsMatcher( ut ensure matcher( Name Expr( matcher ) ) ) )
+  )),
+  "ut typed as( matcher )",
+  "Gets the type of the actual value for an inner matcher. Can be useful if testing a large expression and you want to assert that there is something of a specific type, but you don't care what the actual value is (but a little more specific than ut anything()).",
+  {{"Simple", ut assert that( Expr( 5 + 5 ), ut typed as( "Number" ) ); }}
 );

--- a/Source/Matchers/TypedAs.jsl
+++ b/Source/Matchers/TypedAs.jsl
@@ -52,11 +52,11 @@ Define Class(
 		> ut assert that( Expr( 5 + 5 ), ut typed as( "Number" ) );
 */
 ut matcher factory( 
-  "ut typed as",
-  Expr(Function( {matcher},
-    New Object( UtTypedAsMatcher( ut ensure matcher( Name Expr( matcher ) ) ) )
-  )),
-  "ut typed as( matcher )",
-  "Gets the type of the actual value for an inner matcher. Can be useful if testing a large expression and you want to assert that there is something of a specific type, but you don't care what the actual value is (but a little more specific than ut anything()).",
-  {{"Simple", ut assert that( Expr( 5 + 5 ), ut typed as( "Number" ) ); }}
+	"ut typed as",
+	Expr(Function( {matcher},
+		New Object( UtTypedAsMatcher( ut ensure matcher( Name Expr( matcher ) ) ) )
+	)),
+	"ut typed as( matcher )",
+	"Gets the type of the actual value for an inner matcher. Can be useful if testing a large expression and you want to assert that there is something of a specific type, but you don't care what the actual value is (but a little more specific than ut anything()).",
+	{{"Simple", ut assert that( Expr( 5 + 5 ), ut typed as( "Number" ) ); }}
 );

--- a/Source/Matchers/VectorDiagonal.jsl
+++ b/Source/Matchers/VectorDiagonal.jsl
@@ -83,13 +83,26 @@ Define Class(
 		ut assert that( Expr( m ), ut vec diag( ut every item( 1 ) ) );
 		-------------------------
 */
-ut matcher factory( "ut vec diag" );
-ut vec diag = Function( {matcher},
-	{obj},
-	obj = New Object( UtVectorDiagonalMatcher( ut ensure matcher( Name Expr( matcher ) ) ) );
-	obj:self = obj;
+ut matcher factory(
+  "ut vec diag",
+  Expr(Function( {matcher},
+    {obj},
+    obj = New Object( UtVectorDiagonalMatcher( ut ensure matcher( Name Expr( matcher ) ) ) );
+    obj:self = obj;
+  )),
+  "ut vec diag( matcher )",
+  "Compare using Vec Diag() transformation for a given matrix. Does not assert that the matrix is a diagonal matrix. See ut diagonal for this.",
+  {
+    {
+      "Simple",
+      m = [1 0 0, 0 2 0, 0 0 3];
+      ut assert that( Expr( m ), ut vec diag( [1, 2, 3] ) );
+      
+      m = [1 0 0, 0 1 0, 0 0 1];
+      ut assert that( Expr( m ), ut vec diag( ut every item( 1 ) ) );
+    }
+  }
 );
-
 
 /* 
 	Function: ut diagonal
@@ -111,9 +124,14 @@ ut vec diag = Function( {matcher},
 		ut assert that( Expr( m ), ut diagonal() );
 		-------------------------
 */
-ut matcher factory( "ut diagonal" );
-ut diagonal = Function( {},
-	{obj},
-	obj = New Object( UtDiagonalMatcher() );
-	obj:self = obj;
+ut matcher factory( 
+  "ut diagonal",
+  Expr(Function( {},
+    {obj},
+    obj = New Object( UtDiagonalMatcher() );
+    obj:self = obj;
+  )),
+  "ut diagonal()",
+  "Used to assert that a given matrix is diagonal, meaning it is a square matrix where all off-diagonal elements are zero. Asserts nothing about the diagonal. For example, a square all zero matrix is still considered diagonal.",
+  {{"Simple", m = [1 0 0, 0 2 0, 0 0 3]; ut assert that( Expr( m ), ut diagonal() ); }}
 );

--- a/Source/Matchers/VectorDiagonal.jsl
+++ b/Source/Matchers/VectorDiagonal.jsl
@@ -84,24 +84,24 @@ Define Class(
 		-------------------------
 */
 ut matcher factory(
-  "ut vec diag",
-  Expr(Function( {matcher},
-    {obj},
-    obj = New Object( UtVectorDiagonalMatcher( ut ensure matcher( Name Expr( matcher ) ) ) );
-    obj:self = obj;
-  )),
-  "ut vec diag( matcher )",
-  "Compare using Vec Diag() transformation for a given matrix. Does not assert that the matrix is a diagonal matrix. See ut diagonal for this.",
-  {
-    {
-      "Simple",
-      m = [1 0 0, 0 2 0, 0 0 3];
-      ut assert that( Expr( m ), ut vec diag( [1, 2, 3] ) );
-      
-      m = [1 0 0, 0 1 0, 0 0 1];
-      ut assert that( Expr( m ), ut vec diag( ut every item( 1 ) ) );
-    }
-  }
+	"ut vec diag",
+	Expr(Function( {matcher},
+		{obj},
+		obj = New Object( UtVectorDiagonalMatcher( ut ensure matcher( Name Expr( matcher ) ) ) );
+		obj:self = obj;
+	)),
+	"ut vec diag( matcher )",
+	"Compare using Vec Diag() transformation for a given matrix. Does not assert that the matrix is a diagonal matrix. See ut diagonal for this.",
+	{
+		{
+			"Simple",
+			m = [1 0 0, 0 2 0, 0 0 3];
+			ut assert that( Expr( m ), ut vec diag( [1, 2, 3] ) );
+			
+			m = [1 0 0, 0 1 0, 0 0 1];
+			ut assert that( Expr( m ), ut vec diag( ut every item( 1 ) ) );
+		}
+	}
 );
 
 /* 
@@ -125,13 +125,13 @@ ut matcher factory(
 		-------------------------
 */
 ut matcher factory( 
-  "ut diagonal",
-  Expr(Function( {},
-    {obj},
-    obj = New Object( UtDiagonalMatcher() );
-    obj:self = obj;
-  )),
-  "ut diagonal()",
-  "Used to assert that a given matrix is diagonal, meaning it is a square matrix where all off-diagonal elements are zero. Asserts nothing about the diagonal. For example, a square all zero matrix is still considered diagonal.",
-  {{"Simple", m = [1 0 0, 0 2 0, 0 0 3]; ut assert that( Expr( m ), ut diagonal() ); }}
+	"ut diagonal",
+	Expr(Function( {},
+		{obj},
+		obj = New Object( UtDiagonalMatcher() );
+		obj:self = obj;
+	)),
+	"ut diagonal()",
+	"Used to assert that a given matrix is diagonal, meaning it is a square matrix where all off-diagonal elements are zero. Asserts nothing about the diagonal. For example, a square all zero matrix is still considered diagonal.",
+	{{"Simple", m = [1 0 0, 0 2 0, 0 0 3]; ut assert that( Expr( m ), ut diagonal() ); }}
 );

--- a/Tests/UnitTests/MatcherFactoryTest.jsl
+++ b/Tests/UnitTests/MatcherFactoryTest.jsl
@@ -1,0 +1,78 @@
+﻿// Copyright © 2019, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+MatcherFactoryTests = ut test case( "MatcherFactoryTests" )
+	<<Setup(Expr(
+		saved value = ut should deploy documented functions;
+		prev n documented = N Items( ut documented functions );
+	))
+	<<Teardown(Expr(
+		ut unregister matcher factory("test factory");
+		ut assert value( ut matcher factories, ut not( ut contains( Expr( test factory ) ) ) );
+		ut assert that( Expr( ::test factory() ), ut no throw() );
+		ut should deploy documented functions = saved value;
+	));
+
+ut test(MatcherFactoryTests, "No Function Definition", Expr(
+	ut should deploy documented functions = 1;
+	ut matcher factory("test factory");
+
+	// added as matcher factory
+	ut assert value( ut matcher factories, ut contains( Expr( test factory ) ) );
+	// not added as documented function
+	ut assert value( ut documented functions, ut n items( prev n documented ) );
+	// no function defined
+	ut assert that( Expr( test factory() ), ut throws name unresolved( "test factory" ) );
+
+	test factory = Function({}, 5 ); // make valid function for teardown
+
+));
+
+ut test(MatcherFactoryTests, "Defines Function in Global", Expr(
+	ut should deploy documented functions = 1;
+	ut matcher factory("test factory", Expr(Function({}, 5 )) );
+
+	// added as matcher factory
+	ut assert value( ut matcher factories, ut contains( Expr( test factory ) ) );
+	// added to documented functions list
+	ut assert value( ut documented functions, ut n items( prev n documented + 1 ) );
+	// defined in global
+	ut assert that( Expr( ::test factory() ), 5 );
+	
+	// Function that will get overwritten by a deploy
+	::test factory = Function({}, 10 );
+	
+	ut deploy documented functions();
+	// Should overwrite to original defined function
+	ut assert that( Expr( ::test factory() ), 5 );
+	
+));
+
+ut test(MatcherFactoryTests, "Correct documentation", Expr(
+	ut should deploy documented functions = 1;
+	ut matcher factory("test factory", Expr(Function({}, 5 )), "test factory()", "a description" );
+	
+	ut assert value( ut documented functions, ut n items( ut greater than( 0 ) ) );
+
+	cf = ut documented functions[N Items( ut documented functions)];
+	
+	ut assert value( cf, ut name( "test factory" ) );
+	ut assert value( cf, ut message( "test factory()", "prototype", "Get Prototype" ) );
+	ut assert value( cf, ut message( "a description", "description", "Get Description" ) );
+
+));
+
+ut test(MatcherFactoryTests, "Documented functions turned off", Expr(
+	// Opt out of documented functions
+	ut should deploy documented functions = 0;
+
+	ut matcher factory("test factory", Expr(Function({}, 5 )) );
+
+	// added as matcher factory
+	ut assert value( ut matcher factories, ut contains( Expr( test factory ) ) );
+	// NOT added to documented functions list
+	ut assert value( ut documented functions, ut n items( prev n documented ) );
+	// still defined in global
+	ut assert that( Expr( ::test factory() ), 5 );
+
+));

--- a/Tests/UnitTests/MatcherFactoryTest.jsl
+++ b/Tests/UnitTests/MatcherFactoryTest.jsl
@@ -4,12 +4,14 @@
 MatcherFactoryTests = ut test case( "MatcherFactoryTests" )
 	<<Setup(Expr(
 		should deploy = ut should deploy documented functions;
+		matcher factories = ut matcher factories;
 		documented functions = ut documented functions;
 		ut documented functions = {};
 	))
 	<<Teardown(Expr(
-		ut documented functions = documented functions;
 		ut should deploy documented functions = should deploy;
+		ut matcher factories = matcher factories;
+		ut documented functions = documented functions;
 	));
 
 ut test(MatcherFactoryTests, "MatcherFactoryRegistered", Expr(

--- a/Tests/UnitTests/MatcherFactoryTest.jsl
+++ b/Tests/UnitTests/MatcherFactoryTest.jsl
@@ -3,41 +3,70 @@
 
 MatcherFactoryTests = ut test case( "MatcherFactoryTests" )
 	<<Setup(Expr(
-		saved value = ut should deploy documented functions;
-		prev n documented = N Items( ut documented functions );
+		should deploy = ut should deploy documented functions;
+		documented functions = ut documented functions;
+		ut documented functions = {};
 	))
 	<<Teardown(Expr(
-		ut unregister matcher factory("test factory");
-		ut assert value( ut matcher factories, ut not( ut contains( Expr( test factory ) ) ) );
-		ut assert that( Expr( ::test factory() ), ut no throw() );
-		ut should deploy documented functions = saved value;
+		ut documented functions = documented functions;
+		ut should deploy documented functions = should deploy;
 	));
 
-ut test(MatcherFactoryTests, "No Function Definition", Expr(
+ut test(MatcherFactoryTests, "MatcherFactoryRegistered", Expr(
 	ut should deploy documented functions = 1;
 	ut matcher factory("test factory");
 
 	// added as matcher factory
 	ut assert value( ut matcher factories, ut contains( Expr( test factory ) ) );
-	// not added as documented function
-	ut assert value( ut documented functions, ut n items( prev n documented ) );
+));
+
+ut test(MatcherFactoryTests, "UnregisterRemovesMatcherFactory", Expr(
+	ut should deploy documented functions = 1;
+	ut matcher factory("test factory");
+	
+	ut unregister matcher factory("test factory");
+	ut assert value( ut matcher factories, ut not( ut contains( Expr( test factory ) ) ) );
+));
+
+ut test(MatcherFactoryTests, "NoFunctionDefinitionLeavesUndefined", Expr(
+	ut should deploy documented functions = 1;
+	ut matcher factory("test factory");
+	
 	// no function defined
 	ut assert that( Expr( test factory() ), ut throws name unresolved( "test factory" ) );
 
-	test factory = Function({}, 5 ); // make valid function for teardown
+));
+
+ut test(MatcherFactoryTests, "NoFunctionDefinitionNotDocumented", Expr(
+	ut should deploy documented functions = 1;
+	ut matcher factory("test factory");
+
+	// not added as documented function
+	ut assert value( ut documented functions, ut n items( 0 ) );
 
 ));
 
-ut test(MatcherFactoryTests, "Defines Function in Global", Expr(
+ut test(MatcherFactoryTests, "FunctionDefinitionAssignsToGlobal", Expr(
 	ut should deploy documented functions = 1;
 	ut matcher factory("test factory", Expr(Function({}, 5 )) );
 
-	// added as matcher factory
-	ut assert value( ut matcher factories, ut contains( Expr( test factory ) ) );
-	// added to documented functions list
-	ut assert value( ut documented functions, ut n items( prev n documented + 1 ) );
 	// defined in global
 	ut assert that( Expr( ::test factory() ), 5 );
+	
+));
+
+ut test(MatcherFactoryTests, "FunctionDefinitionAddedAsDocmented", Expr(
+	ut should deploy documented functions = 1;
+	ut matcher factory("test factory", Expr(Function({}, 5 )) );
+
+	// added to documented functions list
+	ut assert value( ut documented functions, ut n items( 1 ) );
+	
+));
+
+ut test(MatcherFactoryTests, "FunctionDefinitionOverwritesAfterDeploy", Expr(
+	ut should deploy documented functions = 1;
+	ut matcher factory("test factory", Expr(Function({}, 5 )) );
 	
 	// Function that will get overwritten by a deploy
 	::test factory = Function({}, 10 );
@@ -46,33 +75,51 @@ ut test(MatcherFactoryTests, "Defines Function in Global", Expr(
 	// Should overwrite to original defined function
 	ut assert that( Expr( ::test factory() ), 5 );
 	
-));
+	// Removing deployed function should not throw
+	ut assert that( Expr( Remove Custom Functions( "::test factory" ) ), ut no throw() );
 
-ut test(MatcherFactoryTests, "Correct documentation", Expr(
+), ut log bench( 0 ) );
+
+ut test(MatcherFactoryTests, "FunctionDefinitionWithDocumentation", Expr(
 	ut should deploy documented functions = 1;
 	ut matcher factory("test factory", Expr(Function({}, 5 )), "test factory()", "a description" );
-	
-	ut assert value( ut documented functions, ut n items( ut greater than( 0 ) ) );
 
-	cf = ut documented functions[N Items( ut documented functions)];
+	cf = ut documented functions[1];
 	
+	// test that all documentation is put in the right place
 	ut assert value( cf, ut name( "test factory" ) );
 	ut assert value( cf, ut message( "test factory()", "prototype", "Get Prototype" ) );
 	ut assert value( cf, ut message( "a description", "description", "Get Description" ) );
 
 ));
 
-ut test(MatcherFactoryTests, "Documented functions turned off", Expr(
+ut test(MatcherFactoryTests, "DocumentationOffNotAddedAsDocumented", Expr(
 	// Opt out of documented functions
 	ut should deploy documented functions = 0;
-
 	ut matcher factory("test factory", Expr(Function({}, 5 )) );
 
-	// added as matcher factory
-	ut assert value( ut matcher factories, ut contains( Expr( test factory ) ) );
 	// NOT added to documented functions list
-	ut assert value( ut documented functions, ut n items( prev n documented ) );
+	ut assert value( ut documented functions, ut n items( 0 ) );
+
+));
+
+ut test(MatcherFactoryTests, "DocumentationOffStillDefinedInGlobal", Expr(
+	// Opt out of documented functions
+	ut should deploy documented functions = 0;
+	ut matcher factory("test factory", Expr(Function({}, 5 )) );
+
 	// still defined in global
 	ut assert that( Expr( ::test factory() ), 5 );
+
+));
+
+ut test(MatcherFactoryTests, "DocumentationOffDoesNotDeploy", Expr(
+	ut should deploy documented functions = 0;
+	ut matcher factory("test factory", Expr(Function({}, 5 )) );
+
+	ut deploy documented functions();
+
+	// Remove Custom Functions should throw when function is not a custom function
+	ut assert that( Expr( Remove Custom Functions( "::test factory" ) ), ut throws( ut anything() ) );
 
 ));


### PR DESCRIPTION
This PR makes it so that matchers, `ut assert that`, `ut assert value`, `ut test`, and `ut test case` show up in the Scripting Index with descriptions and examples. This also provides syntax highlighting for theses functions as well as hover help.

Closes #58.

## Description
The implementation changes the `ut matcher factory` function to not only register the matcher, but also define it using `ut define documented function`. The custom functions can be turned off by setting `ut add custom functions = 0` before including the framework.

### Limitations
The current state of this PR should not change any existing behavior, other than the defining of the custom functions happening later. However, all of the functions will not show up as global functions in the *All Functions* category in addition to a *JSL-Hamcrest* category. 

### Options
So I see a few options for this PR.

1. Leave the implementation as it is and stay global.
2. Put the custom functions in a copy of the namespace, with a name like `ut` or `hc`. This would put the functions in a better spot in the SI (not at the top) and would allow for backwards compatibility with global functions. I don't love this option since it removes the hover help for the global versions.
3. Do # 2, but also copy everything into the namespace, not just the custom functions. This would make it so you could use jsl-hamcrest with `Names Default To Here( 1 )`. This option would require refactoring `ut test` since it currently relies on dynamic scoping rules which would no longer apply.
4. Do # 3, but instead of copying, allow setting where the functions should be defined, either the namespace, global, or both.

Right now I am leaning towards  # 1 right now, and potentially do # 4 in the future.

## Checklist

- [x] **I am adding new or changing current functionality.**
  - [x] I have added or updated the tests for the new or changed functionality in `Tests/UnitTests`.
  - [x] I have added note(s) to `CHANGELOG.md` as necessary.

#### Additional Items
- [x] Update PR template to include SI examples

## Contributing

- [x] I have read and agree to the [Contributor Agreement](https://github.com/sassoftware/jsl-hamcrest/blob/master/ContributorAgreement.txt)

Signed-off-by: Justin Chilton <justin.chilton@jmp.com>
