### PR TITLE
Allow nested ut tests with log bench.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
  - Fixed opening help on Mac and fallback to online help when local help not available (#70)
- - Nested `ut test`s now work with log benching (#63 #72).
+ - Nested `ut test`s now work with log benching (#63 #71).
 
 ## [1.1.0]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
  - Fixed opening help on Mac and fallback to online help when local help not available (#70)
+ - Nested `ut test`s now work with log benching (#63 #72).
 
 ## [1.1.0]
 ### Added

--- a/Source/Core/TestCase.jsl
+++ b/Source/Core/TestCase.jsl
@@ -320,11 +320,6 @@ ut test log benchmark label = Function({case name, test name},
 	Eval Insert( "^ut concat test label( case name, test name, \!"Log Benchmark\!" )^" )
 );
 
-// Variable: ut test buffering reporter
-ut test buffering reporter = New Object("UtBufferingReporter"(Empty()));
-// Variable: ut test filtering reporter
-ut test filtering reporter = New Object("UtSuccessFilteringReporter"(Empty()));
-
 /* 
 	Function: ut test
 		-------------Prototype-------------
@@ -481,8 +476,8 @@ ut define documented function(
 		// Get Do Log Bench() < 0 means don't capture
 		If( _utTestNS:log benchmark << Get Do Log Bench() >= 0,
 			// Replace reporter so event handlers don't happen under Log Capture
-			ut test buffering reporter:inner = ut global reporter;
-			ut global reporter = ut test buffering reporter;
+			_utTestNS:buffering reporter = New Object("UtBufferingReporter"(ut global reporter));
+			ut global reporter = _utTestNS:buffering reporter;
 			
 			// Do Setup, Body, Teardown under Log Capture
 			_utTestNS:log = Log Capture( _utTestNS:setup success = Eval( _utTestNS << Get Value( "run setup expr" ) ) );
@@ -492,14 +487,14 @@ ut define documented function(
 			_utTestNS:log ||= Log Capture( Eval( _utTestNS << Get Value( "run teardown expr" ) ) );
 			
 			// Release results to original reporter and restore it
-			ut global reporter = ut test buffering reporter << release();
+			ut global reporter = _utTestNS:buffering reporter << release();
 			
 			// Do benchmark if requested
 			If( _utTestNS:log benchmark << Get Do Log Bench(),
 				Local({log contents},
 					// Replace reporter so we supress success events
-					ut test filtering reporter:inner = ut global reporter;
-					ut global reporter = ut test filtering reporter;
+					_utTestNS:filtering reporter = New Object("UtSuccessFilteringReporter"(ut global reporter));
+					ut global reporter = _utTestNS:filtering reporter;
 					
 					log contents = _utTestNS:log;
 					// Qualified so that the ut test log benchmark label
@@ -513,7 +508,7 @@ ut define documented function(
 						);
 					);
 					
-					ut global reporter = ut test filtering reporter << release();
+					ut global reporter = _utTestNS:filtering reporter << release();
 				)
 			)
 		,

--- a/Tests/UnitTests/TestCaseLogBenchmarkTest.jsl
+++ b/Tests/UnitTests/TestCaseLogBenchmarkTest.jsl
@@ -37,7 +37,7 @@ ut test(Log Benchmark, "Log Bench On Captures And Asserts Empty Log", Expr(
 	ut assert that(Expr(log), "");
 ));
 
-ut test(Log Benchmark, "Log Bench Default Can Be Changed", Expr(
+ut test(Log Benchmark, "Log Bench Default Off", Expr(
 	old default = ut log bench default;
 	ut log bench default = 0;
 	log = Log Capture(rc = ut with reporter(reporter, Expr(
@@ -46,6 +46,29 @@ ut test(Log Benchmark, "Log Bench Default Can Be Changed", Expr(
 	ut log bench default = old default;
 	ut assert that(Expr(rc), 1);
 	ut assert that(Expr(log), "");
+));
+
+ut test(Log Benchmark, "Log Bench Default On", Expr(
+	old default = ut log bench default;
+	ut log bench default = 1;
+	reporter << Expect Call(Expr(add failure(ut wild, ut wild, ut wild, ut wild, ut wild, ut wild)));
+	log = Log Capture(rc = ut with reporter(reporter, Expr(
+		ut test("case", "name", Expr(Print("stuff")) /*no log bench specified*/);
+	)));
+	ut log bench default = old default;
+	ut assert that(Expr(rc), 0);
+	ut assert that(Expr(log), "" );
+));
+
+ut test(Log Benchmark, "Log Bench Default No Capture", Expr(
+	old default = ut log bench default;
+	ut log bench default = -1;
+	log = Log Capture(rc = ut with reporter(reporter, Expr(
+		ut test("case", "name", Expr(Print("stuff")) /*no log bench specified*/);
+	)));
+	ut log bench default = old default;
+	ut assert that(Expr(rc), 1);
+	ut assert that(Expr(log), ut ignoring whitespace( "\["stuff"]\" ) );
 ));
 
 ut test(Log Benchmark, "Log Bench On Does Not Report Successes", Expr(
@@ -86,4 +109,16 @@ ut test(Log Benchmark, "Log Bench On Can Use a Matcher And Fail", Expr(
 		ut test("case", "name", Expr(Write("stuff")), ut log bench(1));
 	));
 	ut test log benchmark label = Name Expr(old label gen);
+));
+
+ut test(Log Benchmark, "Nested tests can independently use log benchmarking #63", Expr(
+	log = Log Capture(rc = ut with reporter(reporter, Expr(
+		ut test("Outer", "Test Captures", Expr(
+			ut test("Inner", "Test Captures Too", Expr(
+				Print("stuff")
+			), ut log bench(0));
+		), ut log bench(0));
+	)));
+	ut assert that(Expr(rc), 1);
+	ut assert that(Expr(log), "");
 ));


### PR DESCRIPTION
Make new instance of buffering and filtering reporters to allow nested calls to `ut test` with log benching.

Closes #63.

## Checklist
- [x] **I am adding new or changing current functionality.**
  - [x] I have added or updated the tests for the new or changed functionality in `Tests/UnitTests`.
  - [x] I have added note(s) to `CHANGELOG.md` as necessary.

## Contributing

- [x] I have read and agree to the [Contributor Agreement](https://github.com/sassoftware/jsl-hamcrest/blob/master/ContributorAgreement.txt)

Signed-off-by: Justin Chilton <justin.chilton@jmp.com>
