### PR TITLE
Preserve configured global reporter on init.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
  - Nested `ut test`s now work with log benching (#63 #71).
  - `ut equal to` no longer fails with an empty matrix (#72).
  - `ut approx` now properly shows actual value for matrices (#74).
+ - Initializing the addin with an already configured `ut global reporter` will preserve that reporter (#83).
 
 ## [1.1.0]
 ### Added

--- a/Source/Addin/Actions/InitializeFramework.jsl
+++ b/Source/Addin/Actions/InitializeFramework.jsl
@@ -18,11 +18,17 @@ If(!ut meets hamcrest requirements(),
 	Stop();
 );
 
-// If reporter does not exist or is the wrong type, reset the framework
-If(Try((::ut global reporter << Get Name) != "UtWindowDispatchingReporter", 1),
-	Include( "../../All.jsl" );
-	Include( "../Reporters.jsl" );
-	Include( "../TestRunner.jsl" );
-	Include( "../TestRunnerPreferences.jsl" );
-	::ut global reporter = ut window dispatching reporter(ut streaming log reporter());
+// If reporter does not exist or is the wrong type, reset the framework. If we have
+// configured reporter (not UtReporter), then use it as the fallback for the
+// UtWindowDispatchingReporter. Otherwise, use logging for the fallback.
+Local({reporter name, fallback reporter},
+	reporter name = Try(::ut global reporter << Get Name, "UtReporter");
+	If(reporter name != "UtWindowDispatchingReporter",
+		Include( "../../All.jsl" );
+		Include( "../Reporters.jsl" );
+		Include( "../TestRunner.jsl" );
+		Include( "../TestRunnerPreferences.jsl" );
+		fallback reporter = If(reporter name != "UtReporter", ::ut global reporter, ut streaming log reporter());
+		::ut global reporter = ut window dispatching reporter(fallback reporter);
+	);
 );


### PR DESCRIPTION
<!--- Briefly describe your changes in the area below. Mention any issues this PR closes. -->

Closes #83. When initializing the addin, if you had an already configured `ut global reporter` it would  be destroyed. Instead, we now use it as the fallback for the `UtWindowDispatchingReporter`.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Feel free to remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] **I am adding new or changing current functionality.**
  - [ ] I have added or updated the tests for the new or changed functionality in `Tests/UnitTests`.
  - [x] I have added note(s) to `CHANGELOG.md` as necessary.

## Contributing

- [x] I have read and agree to the [Contributor Agreement](https://github.com/sassoftware/jsl-hamcrest/blob/master/ContributorAgreement.txt)

<!--- Replace your name and e-mail below -->
Signed-off-by: Evan McCorkle <Evan.McCorkle@jmp.com>
