### PR TITLE
Add self reference to ApproxDigitsMatcher.

### DIFF
--- a/Source/Matchers/Approx.jsl
+++ b/Source/Matchers/Approx.jsl
@@ -245,7 +245,7 @@ ut matcher factory( "ut approx",
 		---------
 */
 ut matcher factory( "ut approx digits",
-	Expr(Function({val, digits},
+	Expr(Function({val, digits}, {obj},
 		
 		If( 
 			!Is Number( Name Expr( val ) ) & !Is Matrix( Name Expr( val ) ), 
@@ -255,7 +255,8 @@ ut matcher factory( "ut approx digits",
 				Throw("Second argument for ut approx digits() must be a matrix or number of digits." )
 		);
 		
-		New Object( UtApproxDigitsMatcher( val, digits ) );
+		obj = New Object( UtApproxDigitsMatcher( val, digits ) );
+		obj:self = obj;
 	)),
 	"ut approx digits( value, digits )",
 	"Returns a success if the actual value matches the expected value up to N digits. Works only on numbers and matrices.",

--- a/Tests/UnitTests/Matchers/ApproxTest.jsl
+++ b/Tests/UnitTests/Matchers/ApproxTest.jsl
@@ -1,6 +1,7 @@
 ﻿// Copyright © 2019, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+// ut approx
 ut test( "ApproxMatcher", "Mismatch", Expr(
 	mi = ut approx( [6] ) << Matches( [5] );
 	ut assert that( Expr( mi:mismatch ), "5 was not within relative epsilon at position [1, 1] within [5]" );
@@ -28,4 +29,33 @@ ut test( "ApproxMatcher", "MatcherFactory", Expr(
 	ut assert that( Expr( m ), ut instance of( "UtApproxMatcher" ) );
 ));
 
-//TODO: ut digits & ut min lre
+// ut approx digits
+ut test( "ApproxDigitsMatcher", "Mismatch", Expr(
+	mi = ut approx digits( [6.1], 1 ) << Matches( [5.1] );
+	ut assert that( Expr( mi:mismatch ), "5.1 was not within relative epsilon at position [1, 1] within [5.1]" );
+));
+
+ut test( "ApproxDigitsMatcher", "Describe", Expr(
+	m = ut approx digits( [6.1], 1 );
+	ut assert that( Expr( m << describe ), "approximately [6.1] where digits=1" );
+));
+
+ut test( "ApproxDigitsMatcher", "MatchInfoSuccess", Expr(
+	mi = ut approx digits( [6], 1 ) << Matches( [6] );
+	ut assert that( Expr( mi ), ut instance of( "UtMatchInfo" ) );
+	ut assert that( Expr( mi:success ), 1 );
+));
+
+ut test( "ApproxDigitsMatcher", "MatchInfoFailure", Expr(
+	mi = ut approx digits( [6], 1 ) << Matches( [5] );
+	ut assert that( Expr( mi ), ut instance of( "UtMatchInfo" ) );
+	ut assert that( Expr( mi:success ), 0 );
+));
+
+ut test( "ApproxDigitsMatcher", "MatcherFactory", Expr(
+	m = ut approx digits( [6], 1 );
+	ut assert that( Expr( m ), ut instance of( "UtApproxDigitsMatcher" ) );
+));
+
+
+//TODO: ut min lre


### PR DESCRIPTION
This was a bug I created with #75. `UtApproxDigitsMatcher` is a subclass of `UtApproxMatcher`, so it also needed the self reference. Also added some tests so that we are exercising the code a little in our tests.

## Checklist
- [x] **I am adding new or changing current functionality.**
  - [x] I have added or updated the tests for the new or changed functionality in `Tests/UnitTests`.
  - [N/A] I have added note(s) to `CHANGELOG.md` as necessary.

## Contributing

- [x] I have read and agree to the [Contributor Agreement](https://github.com/sassoftware/jsl-hamcrest/blob/master/ContributorAgreement.txt)

<!--- Replace your name and e-mail below -->
Signed-off-by: Justin Chilton <justin.chilton@jmp.com>
