### PR TITLE
Report per ut test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [1.3.0]
+### Changed
+ -JunitXMLReporter now reports failures per test case isntead of per assertion
+
 ## [1.2.0]
 ### Added
  - Custom functions for matcher, assertion, test, and test case functions with examples in the Scripting Index and hover help (#58 #64).
@@ -16,7 +20,7 @@ All notable changes to this project will be documented in this file.
  - Nested `ut test`s now work with log benching (#63 #71).
  - `ut equal to` no longer fails with an empty matrix (#72).
  - `ut approx` now properly shows actual value for matrices (#74).
- - Initializing the addin with an already configured `ut global reporter` will preserve that reporter (#83).
+ - Initializing the addin with an already configured `ut global reporter` will preserve that reporter (#83
 
 ## [1.1.0]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ All notable changes to this project will be documented in this file.
  - Nested `ut test`s now work with log benching (#63 #71).
  - `ut equal to` no longer fails with an empty matrix (#72).
  - `ut approx` now properly shows actual value for matrices (#74).
- - Initializing the addin with an already configured `ut global reporter` will preserve that reporter (#83
+ - Initializing the addin with an already configured `ut global reporter` will preserve that reporter (#83).
 
 ## [1.1.0]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,7 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## [1.3.0]
-### Changed
- -JunitXMLReporter now reports failures per test case isntead of per assertion
-
-## [1.2.0]
+## [HEAD]
 ### Added
  - Custom functions for matcher, assertion, test, and test case functions with examples in the Scripting Index and hover help (#58 #64).
  - Development addin that can be linked to a repository for easy updating (#66)
@@ -14,6 +10,7 @@ All notable changes to this project will be documented in this file.
  - `UtJunitXMLReporter` (#56)
 
 ### Changed
+ -JunitXMLReporter now reports failures per test case instead of per assertion (#87, #77).
 
 ### Fixed
  - Fixed opening help on Mac and fallback to online help when local help not available (#70)

--- a/Source/Reporters/JunitXMLReporter.jsl
+++ b/Source/Reporters/JunitXMLReporter.jsl
@@ -167,7 +167,6 @@ Define Class(
       props = Associative Array();
       props["name"] = test_suites[i];
       props["tests"] = Char(num_tests);
-      show(num_successes);
       props["failures"] = Char(num_tests-num_successes);
       test_suite_tag = this:generate_xml_tag("testsuite", trim(test_case_xml), props, 0);
       content ||= test_suite_tag;
@@ -208,11 +207,11 @@ Define Class(
     Match(NItems(list_label),
       4,
       curr_suite = Trim(list_label[1]);
-      curr_test = Trim(list_label[2]) || "_" || Trim(list_label[3]) /*|| "_" || Trim(list_label[4])*/;
+      curr_test = Trim(list_label[2]) || "_" || Trim(list_label[3]);
       ,
       3,
       curr_suite = Trim(list_label[1]);
-      curr_test = Trim(list_label[2]) /*|| "_" || Trim(list_label[3])*/;
+      curr_test = Trim(list_label[2]);
       ,
       1,
       curr_suite = "Anonymous_Test_Suite";

--- a/Source/Reporters/JunitXMLReporter.jsl
+++ b/Source/Reporters/JunitXMLReporter.jsl
@@ -220,17 +220,6 @@ Define Class(
       // need to increase the number
       anonymous_test_suite = hash_results["Anonymous_Test_Suite"];
       anonymous_test_cases = anonymous_test_suite << get keys;
-
-      // find number of test cases in anonymous_test_suite with form label_XX where XX is any number
-      /*curr_anonymous_test_cases = 0;
-
-      For(curr_key = anonymous_test_suite << First, !isempty(curr_key), curr_key = anonymous_test_suite << Next(curr_key),
-        regex_match = Regex Match(curr_key, "^" || curr_test || "_\d+$");
-        If(NItems(regex_match) | label == curr_key,
-          curr_anonymous_test_cases += 1;
-        );
-      );
-      curr_test ||= "_" || Char(curr_anonymous_test_cases);*/
     );
     Return(Eval List(List(curr_suite, curr_test)));
   );

--- a/Source/Reporters/JunitXMLReporter.jsl
+++ b/Source/Reporters/JunitXMLReporter.jsl
@@ -104,10 +104,10 @@ Define Class(
   ---JSL---
   xml_results = ["Example Tests" => 
                   ["Test1" => 
-                    ["failure" =>
+                    {["failure" =>
                       "Expected: add_nums(1, 1) equal to 3
                       But: was 2"
-                    ]
+                    ]}
                   ]
                 ];
 
@@ -129,28 +129,33 @@ Define Class(
 
   get_xml_report = Method({xml_results},
     start_line = "<?xml version=\!"1.0\!" encoding=\!"UTF-8\!" ?>\!n";
-    
     content = "";
     test_suites = xml_results << get keys;
     test_cases_set = xml_results << get values;
     For(i=1, i<=NItems(test_suites), i++,
-    
-
       test_cases = test_cases_set[i];
       test_case_names = test_cases << get keys;
       test_case_info = test_cases << get values;
       test_case_xml = "";
+      num_tests = 0;
+      num_successes = 0;
       For(k=1, k<=NItems(test_case_names), k++,
 
         info_types = test_case_info[k] << get keys;
         
         test_case_content = "";
         For(l=1, l<=NItems(test_case_info[k]), l++,
-          info_type = info_types[l];
+          num_tests += 1;
+          info_types = test_case_info[k][l] << get keys;
+          // case for a success
+          If(Nitems(info_types) == 0,
+            num_successes += 1;
+            Continue();
+          );
+          info_type = info_types[1];
           props = Associative Array();
           props["type"] = info_type;
-          failure_content = this:generate_xml_tag("failure", test_case_info[k][info_type], props);
-
+          failure_content = this:generate_xml_tag("failure", test_case_info[k][l][info_type], props);
           test_case_content ||= failure_content;
 
         );
@@ -159,13 +164,10 @@ Define Class(
         test_case_xml ||= this:generate_xml_tag("testcase", trim(test_case_content), props, 0);
         
       );
-      num_tests = NItems(test_case_names);
       props = Associative Array();
       props["name"] = test_suites[i];
       props["tests"] = Char(num_tests);
-
-      // find test results that are non empty
-      num_successes = Nitems(loc(test_case_info, [=>]));
+      show(num_successes);
       props["failures"] = Char(num_tests-num_successes);
       test_suite_tag = this:generate_xml_tag("testsuite", trim(test_case_xml), props, 0);
       content ||= test_suite_tag;
@@ -206,11 +208,11 @@ Define Class(
     Match(NItems(list_label),
       4,
       curr_suite = Trim(list_label[1]);
-      curr_test = Trim(list_label[2]) || "_" || Trim(list_label[3]) || "_" || Trim(list_label[4]);
+      curr_test = Trim(list_label[2]) || "_" || Trim(list_label[3]) /*|| "_" || Trim(list_label[4])*/;
       ,
       3,
       curr_suite = Trim(list_label[1]);
-      curr_test = Trim(list_label[2]) || "_" || Trim(list_label[3]);
+      curr_test = Trim(list_label[2]) /*|| "_" || Trim(list_label[3])*/;
       ,
       1,
       curr_suite = "Anonymous_Test_Suite";
@@ -221,7 +223,7 @@ Define Class(
       anonymous_test_cases = anonymous_test_suite << get keys;
 
       // find number of test cases in anonymous_test_suite with form label_XX where XX is any number
-      curr_anonymous_test_cases = 0;
+      /*curr_anonymous_test_cases = 0;
 
       For(curr_key = anonymous_test_suite << First, !isempty(curr_key), curr_key = anonymous_test_suite << Next(curr_key),
         regex_match = Regex Match(curr_key, "^" || curr_test || "_\d+$");
@@ -229,7 +231,7 @@ Define Class(
           curr_anonymous_test_cases += 1;
         );
       );
-      curr_test ||= "_" || Char(curr_anonymous_test_cases);
+      curr_test ||= "_" || Char(curr_anonymous_test_cases);*/
     );
     Return(Eval List(List(curr_suite, curr_test)));
   );
@@ -255,10 +257,14 @@ Define Class(
       // empty for a success
       success_hash = Associative Array();
       If(Contains(hash_results << get keys, curr_suite),
-        // check if test has already been added, can happen for asserts with no suite or test name
-        hash_results[curr_suite][curr_test] = Associative Array();
+        If(Contains(hash_results[curr_suite] << get keys, curr_test),
+          Insert Into(hash_results[curr_suite][curr_test], success_hash);
+          ,
+          hash_results[curr_suite][curr_test] = Eval List({success_hash});
+        )
         ,
-        hash_results[curr_suite] = Associative Array(Eval List({curr_test}), Eval List({success_hash}));
+        success_hash_list = Eval List({success_hash});
+        hash_results[curr_suite] = Associative Array(Eval List({curr_test}), Eval List({success_hash_list}));
       );
     );
 
@@ -279,10 +285,14 @@ Define Class(
       fail_msg = Trim(fail_msg);
       fail_hash = Associative Array(Eval List({"failure"}), Eval List({fail_msg}));
       If(Contains(hash_results << get keys, curr_suite),
-        hash_results[curr_suite][curr_test] = Associative Array(Eval List({"failure"}), Eval List({fail_msg}));
+        If(Contains(hash_results[curr_suite] << get keys, curr_test),
+          Insert Into(hash_results[curr_suite][curr_test], fail_hash);
+          ,
+          hash_results[curr_suite][curr_test] = Eval List({fail_hash});
+        )
         ,
-        hash_results[curr_suite] = Associative Array(Eval List({curr_test}), Eval List({fail_hash}));
-        
+        fail_hash_list = Eval List({fail_hash});
+        hash_results[curr_suite] = Associative Array(Eval List({curr_test}), Eval List({fail_hash_list}));
       );
     );
 
@@ -302,14 +312,17 @@ Define Class(
       throw_msg = Trim(throw_msg);
       throw_hash = Associative Array(Eval List({"failure"}), Eval List({throw_msg}));
       If(Contains(hash_results << get keys, curr_suite),
-        hash_results[curr_suite][curr_test] = Associative Array(Eval List({"failure"}), Eval List({throw_msg}));
+        If(Contains(hash_results[curr_suite] << get keys, curr_test),
+          Insert Into(hash_results[curr_suite][curr_test], throw_hash);
+          ,
+          hash_results[curr_suite][curr_test] = Eval List({throw_hash});
+        )
         ,
-        hash_results[curr_suite] = Associative Array(Eval List({curr_test}), Eval List({throw_hash}));
-        
+        throw_hash_list = Eval List({ throw_hash});
+        hash_results[curr_suite] = Associative Array(Eval List({curr_test}), Eval List({ throw_hash_list}));
       );
 
     );
-      
     this:get_xml_report(hash_results);
   );
   

--- a/Tests/UnitTests/Reporters/JunitXMLReporterTest.jsl
+++ b/Tests/UnitTests/Reporters/JunitXMLReporterTest.jsl
@@ -47,8 +47,8 @@ setup_expr = Expr(
         // This allows us to write assertions that are reported as outside of any test.
         ::ut assert that(ut as expr(Name Expr(value)), matcher, label);
     );
-    //report = Expr(Try(cached_report, cached_report = reporter << get report));
-    report = Expr(reporter << get report);
+    delete symbols(cached_report);
+    report = Expr(Try(cached_report, cached_report = reporter << get report));
 );
 	
 JunitXMLReporters = ut test case("JunitXMLReporters")
@@ -117,6 +117,7 @@ ut test(JunitXMLReporters, "Angle brackets in failure gives valid xml", Expr(
 // 8.0 Counts are correct at root
 
 ut test(JunitXMLReporters, "Counts are correct at root", Expr(
+
 	with junit reporter(Expr(
 		outer assert value(1, 1);
 		outer assert value(2, 0);
@@ -133,6 +134,7 @@ ut test(JunitXMLReporters, "Counts are correct at root", Expr(
 			ut assert value(8, 0);
 		));
 	));
+
 	ut assert that( Expr(n root tests(report)), 8 );
 	ut assert that( Expr(n root failures(report)), 4 );
 	ut assert that( Expr(suite names(report)), {"A", "Anonymous_Test_Suite", "B"} );
@@ -232,7 +234,6 @@ ut test(JunitXMLReporters, "Assertion with 4 part label works", Expr(
 	Substitute Into(pattern, "\!N", ".+", "\!r", ".+", "\!t", "");
 
 	match = Regex Match(report, pattern);
-	
 	ut assert that(Expr(match), ut length(1));
 	ut assert that(Expr(report), ut valid xml() );
 	ut assert that(Expr(match[1]), ut equal to(report));

--- a/Tests/UnitTests/Reporters/JunitXMLReporterTest.jsl
+++ b/Tests/UnitTests/Reporters/JunitXMLReporterTest.jsl
@@ -48,6 +48,7 @@ setup_expr = Expr(
         ::ut assert that(ut as expr(Name Expr(value)), matcher, label);
     );
     report = Expr(Try(cached_report, cached_report = reporter << get report));
+    //report = Expr(reporter << get report);
 );
 	
 JunitXMLReporters = ut test case("JunitXMLReporters")
@@ -120,7 +121,7 @@ ut test(JunitXMLReporters, "Counts are correct at root", Expr(
 		outer assert value(1, 1);
 		outer assert value(2, 0);
 		ut test("A", "a", Expr(
-			ut assert value(3, 3);
+		    ut assert value(3, 3);
 			ut assert value(4, 0);
 		));
 		ut test("A", "1", Expr(
@@ -140,20 +141,19 @@ ut test(JunitXMLReporters, "Counts are correct at root", Expr(
 // 9.0 JunitXMLReporter one simple passing
 
 ut test( JunitXMLReporters, "JunitXMLReporter one simple passing", Expr(
-
+//include("../../../Source/Reporters/JunitXMLReporter.jsl");
+//setup_expr
 	with junit reporter(Expr(
 	   ut test ("Simple Pass", "One plus one equals two", Expr(
 	     ut assert that(Expr(1+1), ut equal to (2));
 	   ));
 	));
-	
 	ut assert that(Expr(reporter << successes), ut equal to ({{"Simple Pass ⮚ One plus one equals two ⮚ 1", 1 + 1, "equal to 2", Empty()}}));
-	
 	pattern = 
 	"\[<\?xml version="1.0" encoding="UTF-8" \?>
 	<testsuites failures="0" id="\d+_\d+" tests="1">
 	  <testsuite failures="0" name="Simple Pass" tests="1">
-		<testcase name="One plus one equals two_1">
+		<testcase name="One plus one equals two">
 		</testcase>
 	  </testsuite>
 	</testsuites>
@@ -185,7 +185,7 @@ ut test( JunitXMLReporters, "JunitXMLReporter one simple failing", Expr(
 	"\[<\?xml version="1.0" encoding="UTF-8" \?>
 	<testsuites failures="1" id="\d+_\d+" tests="1">
 	  <testsuite failures="1" name="Simple Fail" tests="1">
-		<testcase name="One plus one equals one_1">
+		<testcase name="One plus one equals one">
 		  <failure type="failure">
 			Expected: 1 \+ 1 equal to 1
 			But: was 2
@@ -218,7 +218,7 @@ ut test(JunitXMLReporters, "Assertion with 4 part label works", Expr(
 	pattern = "<\?xml version=\!"1.0\!" encoding=\!"UTF-8\!" \?>
 	<testsuites failures=\!"1\!" id=\!"\d+_\d+\!" tests=\!"1\!">
 	  <testsuite failures=\!"1\!" name=\!"A\!" tests=\!"1\!">
-		<testcase name=\!"a_extra info_1\!">
+		<testcase name=\!"a_extra info\!">
 		  <failure type=\!"failure\!">
 			Expected: Expr\(1\) equal to 0
 			But: was 1
@@ -342,29 +342,25 @@ ut test(JunitXMLReporters, "Multiple successes and failure report as expected", 
 	pattern ="<?xml version=\!"1.0\!" encoding=\!"UTF-8\!" ?>
 	<testsuites failures=\!"6\!" id=\!"\d+_\d+\!" tests=\!"10\!">
 	  <testsuite failures=\!"4\!" name=\!"Example Tests\!" tests=\!"6\!">
-		<testcase name=\!"Test1_1\!">
-		</testcase>
-		<testcase name=\!"Test1_2\!">
+		<testcase name=\!"Test1\!">
 		  <failure type=\!"failure\!">
 			Expected: add_nums(1, 1) equal to 3
 			But: was 2
 		  </failure>
 		</testcase>
-		<testcase name=\!"Test2_1\!">
+		<testcase name=\!"Test2\!">
 		  <failure type=\!"failure\!">
 			Expected: add_nums(3, 5) equal to 7
 			But: was 8
 		  </failure>
-		</testcase>
-		<testcase name=\!"Test2_2\!">
 		  <failure type=\!"failure\!">
 			Expected: add_nums(3, 5) equal to 29
 			But: was 8
 		  </failure>
 		</testcase>
-		<testcase name=\!"Test3_1\!">
+		<testcase name=\!"Test3\!">
 		</testcase>
-		<testcase name=\!"Test4_1\!">
+		<testcase name=\!"Test4\!">
 		  <failure type=\!"failure\!">
 			Expected: add_nums(3, 5) equal to 9
 			But: was 8
@@ -372,17 +368,17 @@ ut test(JunitXMLReporters, "Multiple successes and failure report as expected", 
 		</testcase>
 	  </testsuite>
 	  <testsuite failures=\!"2\!" name=\!"Example Tests 2\!" tests=\!"4\!">
-		<testcase name=\!"Test1_1\!">
+		<testcase name=\!"Test1\!">
 		</testcase>
-		<testcase name=\!"Test2_1\!">
+		<testcase name=\!"Test2\!">
 		  <failure type=\!"failure\!">
 			Expected: add_nums(3, 5) equal to 7
 			But: was 8
 		  </failure>
 		</testcase>
-		<testcase name=\!"Test3_1\!">
+		<testcase name=\!"Test3\!">
 		</testcase>
-		<testcase name=\!"Test4_1\!">
+		<testcase name=\!"Test4\!">
 		  <failure type=\!"failure\!">
 			Expected: add_nums(3, 5) equal to 9
 			But: was 8

--- a/Tests/UnitTests/Reporters/JunitXMLReporterTest.jsl
+++ b/Tests/UnitTests/Reporters/JunitXMLReporterTest.jsl
@@ -143,8 +143,6 @@ ut test(JunitXMLReporters, "Counts are correct at root", Expr(
 // 9.0 JunitXMLReporter one simple passing
 
 ut test( JunitXMLReporters, "JunitXMLReporter one simple passing", Expr(
-//include("../../../Source/Reporters/JunitXMLReporter.jsl");
-//setup_expr
 	with junit reporter(Expr(
 	   ut test ("Simple Pass", "One plus one equals two", Expr(
 	     ut assert that(Expr(1+1), ut equal to (2));

--- a/Tests/UnitTests/Reporters/JunitXMLReporterTest.jsl
+++ b/Tests/UnitTests/Reporters/JunitXMLReporterTest.jsl
@@ -47,8 +47,8 @@ setup_expr = Expr(
         // This allows us to write assertions that are reported as outside of any test.
         ::ut assert that(ut as expr(Name Expr(value)), matcher, label);
     );
-    report = Expr(Try(cached_report, cached_report = reporter << get report));
-    //report = Expr(reporter << get report);
+    //report = Expr(Try(cached_report, cached_report = reporter << get report));
+    report = Expr(reporter << get report);
 );
 	
 JunitXMLReporters = ut test case("JunitXMLReporters")


### PR DESCRIPTION
<!--- Briefly describe your changes in the area below. Mention any issues this PR closes. -->
Changes the JUnitXML  reporter to report failures per test case instead of per assertion.

Closes #77.

## Description
<!--- If necessary, go into depth of what this pull request is doing. -->
Changes the JUnitXML  reporter to report failures per test case instead of per assertion.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Feel free to remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->


- [x] **I am adding new or changing current functionality.**
  - [x] I have added or updated the tests for the new or changed functionality in `Tests/UnitTests`.
  - [x] I have added note(s) to `CHANGELOG.md` as necessary.

## Contributing

- [x] I have read and agree to the [Contributor Agreement](https://github.com/sassoftware/jsl-hamcrest/blob/master/ContributorAgreement.txt)

<!--- Replace your name and e-mail below -->
Signed-off-by: Douglas Chong <dougiechong@gmail.com>
