### PR TITLE
Support expr matching for strings with children.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## [1.2.0]
+## [HEAD]
 ### Added
  - Custom functions for matcher, assertion, test, and test case functions with examples in the Scripting Index and hover help (#58 #64).
  - Development addin that can be linked to a repository for easy updating (#66)
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
  - `ut equal to` no longer fails with an empty matrix (#72).
  - `ut approx` now properly shows actual value for matrices (#74).
  - Initializing the addin with an already configured `ut global reporter` will preserve that reporter (#83).
+ - `ut expression matches` now supports strings with children (#88)
 
 ## [1.1.0]
 ### Added

--- a/Source/Core/Matchers/EqualTo.jsl
+++ b/Source/Core/Matchers/EqualTo.jsl
@@ -257,8 +257,8 @@ Define Class(
 	// A match info of information about the success or failure
 	matches = Method( {test expr},
 		actual = test expr;
-		If( !Is Expr( name expr( actual ) ),
-			mismatch = Eval Insert( "was ^Char( Name Expr( actual ) )^" ); 
+		If( !Is Expr( name expr( actual ) ) & N Arg(actual) == 0,
+			mismatch = Eval Insert( "was non-expression ^Char( Name Expr( actual ) )^" ); 
 			Return( ::ut match info failure( mismatch ) );
 		);
 		valueTree = create tree( name expr( this:value ), 1 );
@@ -304,7 +304,7 @@ Define Class(
 		data["head"] = head( rootExpr );
 		
 		If( isPattern,
-			If( Is Expr( name expr( rootExpr ) ),
+			If( Is Expr( name expr( rootExpr ) ) | N Arg( rootExpr ) > 0,
 				
 				If( Head( rootExpr ) == Expr( ut optional() ),
 					data["required"] = 0;
@@ -592,6 +592,13 @@ ut matcher factory( "ut equal to",
 		,
 			"Namespace",
 				New Object( UtEqualToNamespaceMatcher() )
+		,
+			"String",
+				// only use the composite matcher if string has children
+				If( NArg( val ) > 0,
+					New Object( UtExpressionCompositeMatcher() ),
+					New Object( UtEqualToMatcher() )
+				)
 		,
 			// default
 				New Object( UtEqualToMatcher() );

--- a/Tests/UnitTests/Matchers/EqualToTest.jsl
+++ b/Tests/UnitTests/Matchers/EqualToTest.jsl
@@ -35,4 +35,17 @@ ut test( "EqualToMatrixMatcher", "TwoEmptyMatricesAreEqual", Expr(
 	ut assert value( match info:success, 1 );
 ));
 
+ut test( "EqualToMatcher", "Handles Strings", Expr(
+	ut assert value("abc", ut equal to("abc"));
+	ut assert value("abc", ut not(ut equal to("ab")));
+	ut assert value("abc", ut not(ut equal to("ABC")));
+	ut assert value("abc", ut not(ut equal to("abcdef")));
+));
+
+ut test( "EqualToMatcher", "Handles Strings With Children (#88)", Expr(
+	ut assert value("abc"(1, 2, 3), ut equal to("abc"(1, 2, 3)));
+	ut assert value("abc"(1, 2, 3), ut not(ut equal to(Expr("ab"(1, 2, 3)))));
+	ut assert value("abc"(1, 2, 3), ut not(ut equal to(Expr("abc"(4, 5)))));
+));
+
 // TODO: Other EqualToMatcher subclasses

--- a/Tests/UnitTests/Matchers/ExpressionMatchesTest.jsl
+++ b/Tests/UnitTests/Matchers/ExpressionMatchesTest.jsl
@@ -1,0 +1,53 @@
+﻿// Copyright © 2019, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+ut test( "Expression Matches", "Mismatch", Expr(
+	mi = ut expression matches( Expr(1 + 2) ) << Matches( Expr(Expr(3 + 4)) );
+	ut assert that( Expr( mi:mismatch ), "/Add()[1] was 3 but expected equal to 1 within 3 + 4" );
+));
+
+ut test( "Expression Matches", "Describe", Expr(
+	m = ut expression matches( Expr(1 + 2) );
+	ut assert that( Expr( m << Describe ), "equal to 1 + 2" );
+));
+
+ut test( "Expression Matches", "MatchInfo Success", Expr(
+	mi = ut expression matches( Expr(1 + 2) ) << Matches( Expr(Expr(1 + 2)) );
+    ut assert that( Expr( mi ), ut instance of( "UtMatchInfo" ) );
+	ut assert that( Expr( mi:success ), 1 );
+));
+
+ut test( "Expression Matches", "MatchInfo Failure", Expr(
+	mi = ut expression matches( Expr(1 + 2) ) << Matches( Expr(Expr(3 + 4)) );
+	ut assert that( Expr( mi ), ut instance of( "UtMatchInfo" ) );
+	ut assert that( Expr( mi:success ), 0 );
+));
+
+ut test( "Expression Matches", "Matcher Factory", Expr(
+	m = ut expression matches( Expr(1 + 2) );
+	ut assert that( Expr( m ), ut instance of( "UtExpressionCompositeMatcher" ) );
+));
+
+ut test( "Expression Matches", "Strings Can Have Children (#88)", Expr(
+	ut assert value("abc"(1, 2, 3), ut expression matches("abc"(1, 2, 3)));
+	ut assert value("abc"(1, 2, 3), ut expression matches("abc"(ut wild(), 2, 3)));
+	ut assert value("abc"(1, 2, 3), ut not(ut expression matches("ac"(1, 2, 3))));
+	ut assert value("abc"(1, 2, 3), ut not(ut expression matches("abc"(., 2, 3))));
+	ut assert value("abc"(1, 2, 3), ut not(ut expression matches("abc"(1, 2, 3, 4))));
+	ut assert value("abc"(1, 2, 3), ut not(ut expression matches("abc"(1, ut greater than(2), 3))));
+));
+
+ut test( "Expression Matches", "Strings Can Have Children (Within List, #88)", Expr(
+	ut assert value({"abc"(1, 2, 3)}, ut expression matches({"abc"(1, 2, 3)}));
+	ut assert value({"abc"(1, 2, 3)}, ut expression matches({"abc"(ut wild(), 2, 3)}));
+	ut assert value({"abc"(1, 2, 3)}, ut not(ut expression matches({"ac"(1, 2, 3)})));
+	ut assert value({"abc"(1, 2, 3)}, ut not(ut expression matches({"abc"(., 2, 3)})));
+	ut assert value({"abc"(1, 2, 3)}, ut not(ut expression matches({"abc"(1, 2, 3, 4)})));
+	ut assert value({"abc"(1, 2, 3)}, ut not(ut expression matches({"abc"(1, ut greater than(2), 3)})));
+));
+
+ut test( "Expression Matches", "With Strings (#88)", Expr(
+	ut assert value(Expr("abc" || "def"), ut expression matches(Expr("abc" || "def")));
+	ut assert value(Expr("abc" || "def"), ut not(ut expression matches(Expr("ABC" || "def"))));
+	ut assert value(Expr("abc" || "def"), ut not(ut expression matches(Expr("abc"(1, 2, 3) || "def"))));
+));


### PR DESCRIPTION
<!--- Briefly describe your changes in the area below. Mention any issues this PR closes. -->
Closes #88 

This changes the `UtExpressionCompositeMatcher` so that it will properly compare children when matching with a test expression of the form `"string"("with children", 2)`

## Checklist

- [x] **I am adding new or changing current functionality.**
  - [x] I have added or updated the tests for the new or changed functionality in `Tests/UnitTests`.
  - [x] I have added note(s) to `CHANGELOG.md` as necessary.

## Contributing

- [x] I have read and agree to the [Contributor Agreement](https://github.com/sassoftware/jsl-hamcrest/blob/master/ContributorAgreement.txt)

<!--- Replace your name and e-mail below -->
Signed-off-by: Evan McCorkle <Evan.McCorkle@jmp.com>
