### PR TITLE
Promote UtCompositeReporter from Addin only.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
  - Development addin that can be linked to a repository for easy updating (#66)
  - `ut valid xml` matcher (#56)
  - `UtJunitXMLReporter` (#56)
+ - `UtCompositeReporter` now available in base package (#90)
 
 ### Changed
  -JunitXMLReporter now reports failures per test case instead of per assertion (#87, #77).

--- a/Source/Addin/Reporters.jsl
+++ b/Source/Addin/Reporters.jsl
@@ -58,46 +58,6 @@ ut summary reporter = Function({box},
 );
 
 /* 
-	Class: UtCompositeReporter
-		---Prototype---
-		class UtCompositeReporter inherits UtReporter
-		---------------
-		
-		Forward all messages (unchanged) to an inner list of reporters.
-*/
-Define Class("UtCompositeReporter",
-	Base Class( "UtReporter" ),
-	reporters = {};
-	_init_ = Method( {reporters},
-		this:reporters = reporters
-	);
-	add expression failure = Method( {label, payload=Empty()},
-		this:reporters << add expression failure( label, payload )
-	);
-	add failure = Method( {label, test expr, description, mismatch, lre, payload=Empty()},
-		this:reporters << add failure( label, Name Expr( test expr ), description, mismatch, lre, payload )
-	);
-	add unexpected throw = Method( {label, test expr, description, exception, payload=Empty()},
-		this:reporters << add unexpected throw( label, Name Expr( test expr ), description, exception, payload )
-	);
-	add success = Method( {label, test expr, description, payload=Empty()},
-		this:reporters << add success( label, Name Expr( test expr ), description, payload )
-	);
-	on run start = Method( {},
-		this:reporters << on run start()
-	);
-	on run end = Method( {},
-		this:reporters << on run end()
-	);
-);
-
-// Function: ut composite reporter
-// Factory for <UtCompositeReporter>
-ut composite reporter = Function({reporters},
-	New Object( "UtCompositeReporter"( reporters ) )
-);
-
-/* 
 	Class: UtWindowDispatchingReporter
 		---Prototype---
 		class UtWindowDispatchingReporter inherits UtCompositeReporter

--- a/Source/Reporters/CompositeReporter.jsl
+++ b/Source/Reporters/CompositeReporter.jsl
@@ -1,0 +1,32 @@
+
+/* 
+	Class: UtCompositeReporter
+		---Prototype---
+		class UtCompositeReporter inherits UtReporter
+		---------------
+*/
+Define Class("UtCompositeReporter",
+	Base Class( "UtReporter" ),
+	reporters = {};
+	_init_ = Method( {reporters},
+		this:reporters = reporters
+	);
+	add expression failure = Method( {label, payload=Empty()},
+		this:reporters << add expression failure( label, payload )
+	);
+	add failure = Method( {label, test expr, description, mismatch, lre, payload=Empty()},
+		this:reporters << add failure( label, Name Expr( test expr ), description, mismatch, lre, payload )
+	);
+	add unexpected throw = Method( {label, test expr, description, exception, payload=Empty()},
+		this:reporters << add unexpected throw( label, Name Expr( test expr ), description, exception, payload )
+	);
+	add success = Method( {label, test expr, description, payload=Empty()},
+		this:reporters << add success( label, Name Expr( test expr ), description, payload )
+	);
+);
+
+// Function: ut composite reporter
+// Factory for <UtCompositeReporter>
+ut composite reporter = Function({reporters},
+	New Object( "UtCompositeReporter"( reporters ) )
+);

--- a/Source/Reporters/CompositeReporter.jsl
+++ b/Source/Reporters/CompositeReporter.jsl
@@ -12,16 +12,16 @@ Define Class("UtCompositeReporter",
 		this:reporters = reporters
 	);
 	add expression failure = Method( {label, payload=Empty()},
-		this:reporters << add expression failure( label, payload )
+		this:reporters << add expression failure( label, Name Expr( payload ) )
 	);
 	add failure = Method( {label, test expr, description, mismatch, lre, payload=Empty()},
-		this:reporters << add failure( label, Name Expr( test expr ), description, mismatch, lre, payload )
+		this:reporters << add failure( label, Name Expr( test expr ), description, mismatch, lre, Name Expr( payload ) )
 	);
 	add unexpected throw = Method( {label, test expr, description, exception, payload=Empty()},
-		this:reporters << add unexpected throw( label, Name Expr( test expr ), description, exception, payload )
+		this:reporters << add unexpected throw( label, Name Expr( test expr ), description, exception, Name Expr( payload ) )
 	);
 	add success = Method( {label, test expr, description, payload=Empty()},
-		this:reporters << add success( label, Name Expr( test expr ), description, payload )
+		this:reporters << add success( label, Name Expr( test expr ), description, Name Expr( payload ) )
 	);
 );
 

--- a/Tests/UnitTests/Reporters/CompositeReporter.jsl
+++ b/Tests/UnitTests/Reporters/CompositeReporter.jsl
@@ -1,0 +1,35 @@
+
+CompositeReporterTests = ut test case("CompositeReporter")
+	<<Setup(Expr(
+		reporter1 = ut mock reporter();
+		reporter2 = ut mock reporter();
+		composite reporter = ut composite reporter( Eval List( {reporter1, reporter2} ) );
+	))
+	<<Teardown(Expr(
+		reporter1 << Verify Expectations;
+		reporter2 << Verify Expectations;
+	));
+
+ut test(CompositeReporterTests, "Forwards Successes", Expr(
+	reporter1 << Expect Call( Expr( add success("label", "test expr", "description", "payload") ) );
+	reporter2 << Expect Call( Expr( add success("label", "test expr", "description", "payload") ) );
+	composite reporter << Add Success("label", "test expr", "description", "payload");
+));
+
+ut test(CompositeReporterTests, "Forwards Failures", Expr(
+	reporter1 << Expect Call( Expr( add failure("label", "test expr", "description", "mismatch", "lre", "payload") ) );
+	reporter2 << Expect Call( Expr( add failure("label", "test expr", "description", "mismatch", "lre", "payload") ) );
+	composite reporter << Add Failure("label", "test expr", "description", "mismatch", "lre", "payload");
+));
+
+ut test(CompositeReporterTests, "Forwards Expression Failures", Expr(
+	reporter1 << Expect Call( Expr( add expression failure("label", "payload") ) );
+	reporter2 << Expect Call( Expr( add expression failure("label", "payload") ) );
+	composite reporter << Add Expression Failure("label", "payload");
+));
+
+ut test(CompositeReporterTests, "Forwards Unexpected Throws", Expr(
+	reporter1 << Expect Call( Expr( add unexpected throw("label", "test expr", "description", "exception", "payload") ) );
+	reporter2 << Expect Call( Expr( add unexpected throw("label", "test expr", "description", "exception", "payload") ) );
+	composite reporter << Add Unexpected Throw("label", "test expr", "description", "exception", "payload");
+));


### PR DESCRIPTION
Move the `UtCompositeReporter` to the main library.

The only consumer was `UtWindowDispatchingReporter` which used it as a base class. Since it re-defined the `on run start` and `on run end` methods, I just removed them from `UtCompositeReporter` without creating an additional base class.

## Checklist

- [x] **I am adding a new reporter.**
  - [x] I have included documentation with at least one example and description.
  - [x] I have added tests in `Tests/UnitTests/Reporters`.
  - [x] I have added a note to `CHANGELOG.md`.

## Contributing

- [x] I have read and agree to the [Contributor Agreement](https://github.com/sassoftware/jsl-hamcrest/blob/master/ContributorAgreement.txt)

Signed-off-by: Justin Chilton <justin.chilton@jmp.com>
