### PR TITLE
Create function for new objects with self refs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,8 +187,7 @@ ut day of week = Function( {val},
 	If( !Is Number( val ),
 		Throw( "ut day of week() requires a numeric date value as the argument" ),
 	);
-	obj = New Object( UtDayOfWeekMatcher( Name Expr( val ) ) );
-	obj:self = obj;
+	ut new object( "UtDayOfWeekMatcher", Eval List( {Name Expr( val )} ) );
 );
 ```
 

--- a/Source/Core/TestCase.jsl
+++ b/Source/Core/TestCase.jsl
@@ -150,14 +150,7 @@ Define Class(
 ut define documented function(
 	"ut test case",
 	Expr(Function({name},
-		{obj},
-		obj = New Object( UtTestCaseFixture( name ) );
-		
-		// Set a reference to itself.
-		obj:self = local:obj;
-		
-		// return the object
-		obj
+		ut new object( "UtTestCaseFixture", Eval List({name}) );
 	)),
 	"ut test case( test case name )",
 	"Used to isolate a test case from other code in the test file. Also prepends the name of the test and assert number to the beginning of the labels for ut assert that.",

--- a/Source/Core/Utils.jsl
+++ b/Source/Core/Utils.jsl
@@ -516,6 +516,30 @@ ut expr literal = Function( {an expr},
 	Insert( Expr( Expr() ), Name Expr( an expr ) )
 );
 
+/*	Function: ut new object
+		---Prototype---
+		ut new object( String class_name, List args = {} )
+		---------------
+		Creates a new object with a self reference.
+	
+	Arguments:
+		class_name - name of the JSL defined class to create
+		args - arguments passed to the constructor of the class
+	
+	Example:
+		---JSL---
+		Define Class("Foo", 
+			self = Empty();
+			_init_ = Method({x}, this:x = x);
+		);
+		obj = ut new object( "Foo", {5} );
+		---------
+*/
+ut new object = Function({class name, args={}}, {obj},
+	obj = New Object( class name, args );
+	obj:self = obj;
+);
+
 // Variable: ut concat test label sep
 ut concat test label sep = "⮚";
 

--- a/Source/Matchers/Approx.jsl
+++ b/Source/Matchers/Approx.jsl
@@ -1,4 +1,4 @@
-// Copyright © 2019, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
+﻿// Copyright © 2019, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 Names Default To Here( 0 );
@@ -191,7 +191,7 @@ Define Class(
 */
 ut matcher factory( "ut approx",
 	Expr(Function( {val, options={Zero Epsilon( 1e-12 ), Relative Epsilon( 1e-9 )}},
-		{ze, re, obj},
+		{ze, re},
 		If( 
 			!Is Number( Name Expr( val ) ) & !Is Matrix( Name Expr( val ) ),
 				Throw("First argument for ut approx() must be a number or matrix." );
@@ -208,8 +208,7 @@ ut matcher factory( "ut approx",
 			);
 		);
 		
-		obj = New Object( UtApproxMatcher( val, ze, re ) );
-		obj:self = obj;
+		ut new object( "UtApproxMatcher", Eval List( {val, ze, re} ) );
 	)),
 	"ut approx( value, <options> )",
 	"Returns a success if the relative difference between expected and actual is within the relative epsilon for non-zero values and within zero epsilon if the expected or actual value is 0. Works only on numbers and matrices.",
@@ -255,8 +254,7 @@ ut matcher factory( "ut approx digits",
 				Throw("Second argument for ut approx digits() must be a matrix or number of digits." )
 		);
 		
-		obj = New Object( UtApproxDigitsMatcher( val, digits ) );
-		obj:self = obj;
+		ut new object( "UtApproxDigitsMatcher", Eval List( {val, digits} ) );
 	)),
 	"ut approx digits( value, digits )",
 	"Returns a success if the actual value matches the expected value up to N digits. Works only on numbers and matrices.",

--- a/Source/Matchers/InstanceOf.jsl
+++ b/Source/Matchers/InstanceOf.jsl
@@ -58,8 +58,7 @@ ut matcher factory(
 		{obj},
 		If( !Is String( Name Expr( val ) ),
 			Throw( "argument to ut instance of() must be a string" ),
-			obj = New Object( UtInstanceOfMatcher( val ) );
-			obj:self = obj;
+			ut new object( "UtInstanceOfMatcher", Eval List({val}) );
 		);
 	)),
 	"ut instance of( value )",

--- a/Source/Matchers/Messages.jsl
+++ b/Source/Matchers/Messages.jsl
@@ -53,8 +53,7 @@ ut matcher factory(
 	"ut message",
 	Expr(Function( {matcher, description, message},
 		{obj},
-		obj = New Object( UtMessageMatcher( ut ensure matcher( Name Expr( matcher ) ), description, message ) );
-		obj:self = obj;
+		ut new object( "UtMessageMatcher", Eval List( {ut ensure matcher( Name Expr( matcher ) ), description, message} ) );
 	)),
 	"ut message( matcher, description, message )",
 	"General message matcher factory. Mostly used in other factory functions, but can be used in tests if needed."

--- a/Source/Matchers/VectorDiagonal.jsl
+++ b/Source/Matchers/VectorDiagonal.jsl
@@ -87,8 +87,7 @@ ut matcher factory(
 	"ut vec diag",
 	Expr(Function( {matcher},
 		{obj},
-		obj = New Object( UtVectorDiagonalMatcher( ut ensure matcher( Name Expr( matcher ) ) ) );
-		obj:self = obj;
+		ut new object( "UtVectorDiagonalMatcher", Eval List({ut ensure matcher( Name Expr( matcher ) )} ) );
 	)),
 	"ut vec diag( matcher )",
 	"Compare using Vec Diag() transformation for a given matrix. Does not assert that the matrix is a diagonal matrix. See ut diagonal for this.",
@@ -128,8 +127,7 @@ ut matcher factory(
 	"ut diagonal",
 	Expr(Function( {},
 		{obj},
-		obj = New Object( UtDiagonalMatcher() );
-		obj:self = obj;
+		ut new object( "UtDiagonalMatcher" );
 	)),
 	"ut diagonal()",
 	"Used to assert that a given matrix is diagonal, meaning it is a square matrix where all off-diagonal elements are zero. Asserts nothing about the diagonal. For example, a square all zero matrix is still considered diagonal.",

--- a/Source/Matchers/Xml.jsl
+++ b/Source/Matchers/Xml.jsl
@@ -42,6 +42,5 @@ Define Class(
 */
 ut matcher factory( "ut valid xml" );
 ut valid xml = Function( {},
-	obj = New Object("UtValidXmlMatcher");
-	obj:self = obj;	
+	ut new object("UtValidXmlMatcher");
 );

--- a/Tests/RunTests.jsl
+++ b/Tests/RunTests.jsl
@@ -35,9 +35,7 @@ Define Class("UtMockReporter",
 );
 
 ut mock reporter = Function({}, {obj},
-	obj = New Object("UtMockReporter");
-	obj:self = obj;
-	obj
+	ut new object("UtMockReporter");
 );
 
 ut include jsl files recursively( "UnitTests" );

--- a/Tests/UnitTests/UtilsTests.jsl
+++ b/Tests/UnitTests/UtilsTests.jsl
@@ -87,6 +87,13 @@ ut test( "Utils", "ExprLiteral", Expr(
     ut assert that( Expr( ut expr literal( Name Expr( add expr ) ) ), Expr( Expr( 5 + 5 ) ) );
 ));
 
+ut test( "Utils", "NewObject", Expr(
+	Define Class("Foo");
+	obj = ut new object("Foo");
+	ut assert value(obj, ut instance of("Foo"));
+	ut assert that(Expr(obj:self), obj, "Self is a reference to itself");
+));
+
 ut test( "Utils", "MoveToAnonymousNamespace", Expr(
     ns = New Namespace();
     ns:x = 5;


### PR DESCRIPTION
Creates a new function called `ut new object` which creates new objects with self references. This PR also changes places where we do this to use this new function. Should make us less likely to make mistakes when refactoring matchers to a `UtTypedMatcher` base class.

Closes #41.

## Checklist

- [x] **I am adding new or changing current functionality.**
  - [x] I have added or updated the tests for the new or changed functionality in `Tests/UnitTests`.
  - [N/A] I have added note(s) to `CHANGELOG.md` as necessary.

## Contributing

- [x] I have read and agree to the [Contributor Agreement](https://github.com/sassoftware/jsl-hamcrest/blob/master/ContributorAgreement.txt)

Signed-off-by: Justin Chilton <justin.chilton@jmp.com>
