### PR TITLE
Fix FileAppendingReporter factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to this project will be documented in this file.
 - `ut approx` now properly shows actual value for matrices (#74).
 - Initializing the addin with an already configured `ut global reporter` will preserve that reporter (#83).
 - `ut expression matches` now supports strings with children (#88)
+- `ut file appending reporter` factory function now works properly (#96).
 
 ## [1.1.0]
 

--- a/Source/Reporters/FileAppendingReporter.jsl
+++ b/Source/Reporters/FileAppendingReporter.jsl
@@ -55,8 +55,19 @@ Define Class(
 	);
 );
 
-// Function: ut file appending reporter
-//   Factory for <UtFileAppendingReporter>.
-ut file appending reporter = Function({},
-	New Object( "UtFileAppendingReporter" );
+/*  Function: ut file appending reporter
+      Reporter which appends failures as they happen to an output file.
+
+      Factory for <UtFileAppendingReporter>.
+   
+    Arguments:
+      file - filepath for output file 
+    
+    Example:
+    ---JSL---
+    ut global reporter = ut file appending reporter( "$DESKTOP/report.txt" );
+    ---------
+*/
+ut file appending reporter = Function({file},
+	New Object( "UtFileAppendingReporter"( file ) );
 );

--- a/Tests/UnitTests/Reporters/FileAppendingReporterTest.jsl
+++ b/Tests/UnitTests/Reporters/FileAppendingReporterTest.jsl
@@ -1,0 +1,20 @@
+
+FileAppendingReporterTests = ut test case("FileAppendingReporter") 
+  <<Setup(Expr(
+    reporter path = "$temp/fileAppendingReporter.txt";
+    Delete File(reporter path);
+    reporter = ut file appending reporter(reporter path);
+  ));
+
+ut test(FileAppendingReporterTests, "FactoryFunction", Expr(
+  ut assert value(reporter, ut instance of("UtFileAppendingReporter"));
+));
+
+ut test(FileAppendingReporterTests, "CreatesFile", Expr(
+  ut assert value(File Exists(reporter path), 1);
+));
+
+ut test(FileAppendingReporterTests, "AddsFailuresToFile", Expr(
+  reporter << Add Failure("label", "test expr", "description", "mismatch", Empty());
+  ut assert value(File Size(reporter path), ut greater than(10));
+));


### PR DESCRIPTION
This PR fixes the `ut file appending reporter` factory that was missing an argument. I also added some additional tests for this reporter.

## Checklist

- [x] **I am adding new or changing current functionality.**
  - [x] I have added or updated the tests for the new or changed functionality in `Tests/UnitTests`.
  - [x] I have added note(s) to `CHANGELOG.md` as necessary.

## Contributing

- [x] I have read and agree to the [Contributor Agreement](https://github.com/sassoftware/jsl-hamcrest/blob/master/ContributorAgreement.txt)

Signed-off-by: Justin Chilton <justin.chilton@jmp.com>
