### PR TITLE
Reset current row when ut test finishes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to this project will be documented in this file.
 - Initializing the addin with an already configured `ut global reporter` will preserve that reporter (#83).
 - `ut expression matches` now supports strings with children (#88)
 - `ut file appending reporter` factory function now works properly (#96).
+- `ut test` now saves and restores the current row number to better isolate tests (#97).
 
 ## [1.1.0]
 

--- a/Source/Core/TestCase.jsl
+++ b/Source/Core/TestCase.jsl
@@ -390,6 +390,8 @@ ut define documented function(
 		
 		// get the symbols defined before running the test case
 		_utTestNS:before symbols = ::ut get symbol information();
+		// get the current row before running the test case
+		_utTestNS:before row = Row();
 		
 		_utTestNS:n asserts = 0;
 		_utTestNS:results = {};
@@ -517,6 +519,8 @@ ut define documented function(
 		
 		// delete the symbols that were added during the test
 		::ut delete symbols difference( _utTestNS:before symbols, _utTestNS:after symbols, 1 /* Close Windows */ );
+		// restore the current row in case it was changed
+		Row() = _utTestNS:before row;
 		
 		// Return whether or not all asserts passed
 		First( All( _utTestNS:results ), Delete Namespaces( Force( 1 ), _utTestNS ) );

--- a/Tests/UnitTests/TestCaseTest.jsl
+++ b/Tests/UnitTests/TestCaseTest.jsl
@@ -1,4 +1,4 @@
-// Copyright © 2019, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
+﻿// Copyright © 2019, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // TODO: 
@@ -32,3 +32,35 @@ test case rc = with noop reporter( Expr(
 	);
 ));
 ut assert that( Expr( test case rc ), 0 );
+
+
+// Reset Row() after test
+Row() = 0;
+assert rc = with noop reporter( Expr(
+	ut test( "Reset Row", "To Unset", Expr(
+		Row() = 5;
+		ut assert that( Expr( Row() ), 5 );
+	))
+));
+ut assert that( Expr( assert rc ), 1, "Row set within test" );
+ut assert that( Expr( Row() ), 0, "Row restored to unset" );
+
+Row() = 101;
+assert rc = with noop reporter( Expr(
+	ut test( "Reset Row", "To Unset", Expr(
+		Row() = 5;
+		ut assert that( Expr( Row() ), 5 );
+	))
+));
+ut assert that( Expr( assert rc ), 1, "Row set within test" );
+ut assert that( Expr( Row() ), 101, "Row restored to set" );
+
+Row() = 201;
+assert rc = with noop reporter( Expr(
+	ut test( "Reset Row", "To Unset", Expr(
+		Row() = 0;
+		ut assert that( Expr( Row() ), 0 );
+	))
+));
+ut assert that( Expr( assert rc ), 1, "Row unset within test" );
+ut assert that( Expr( Row() ), 201, "Row restored to set" );


### PR DESCRIPTION
Closes #97 

This changes `ut test` so that it saves and restores the current row to better isolate tests.

## Checklist
- [x] **I am adding new or changing current functionality.**
  - [x] I have added or updated the tests for the new or changed functionality in `Tests/UnitTests`.
  - [x] I have added note(s) to `CHANGELOG.md` as necessary.

## Contributing

- [x] I have read and agree to the [Contributor Agreement](https://github.com/sassoftware/jsl-hamcrest/blob/master/ContributorAgreement.txt)

Signed-off-by: Evan McCorkle <Evan.McCorkle@jmp.com>
