### PR TITLE
Ensure TestRunner GUI uses on run start/end.

### DIFF
--- a/Source/Addin/Reporters.jsl
+++ b/Source/Addin/Reporters.jsl
@@ -57,6 +57,31 @@ ut summary reporter = Function({box},
 	New Object( "UtSummaryReporter"( box ) )
 );
 
+/*
+	Class: UtCompositeRunReporter
+		---Prototype----
+		class UtCompositeRunReporter inherits UtCompositeReporter
+		----------------
+
+		This is just like UtCompositeReporter but with additional
+		on run start and on run end messages.
+*/
+Define Class("UtCompositeRunReporter",
+	Base Class( "UtCompositeReporter" ),
+	on run start = Method( {},
+		this:reporters << on run start()
+	);
+	on run end = Method( {},
+		this:reporters << on run end()
+	)
+);
+
+// Function: ut composite run reporter
+// Factory for <UtCompositeRunReporter>
+ut composite run reporter = Function({reporters},
+	New Object( "UtCompositeRunReporter"( reporters ) )
+);
+
 /* 
 	Class: UtWindowDispatchingReporter
 		---Prototype---

--- a/Source/Addin/TestRunner.jsl
+++ b/Source/Addin/TestRunner.jsl
@@ -144,7 +144,7 @@ ut make reporter gui = Function({position},
 	Insert Into(reporters, ut busy reporter(busy));
 	Insert Into(reporters, ut timing reporter(timing));
 	Insert Into(reporters, ut details tree reporter(details));
-	reporter = ut composite reporter(reporters);
+	reporter = ut composite run reporter(reporters);
 	reporter:position = position;
 	Eval List({box, reporter})
 );


### PR DESCRIPTION
Moving `UtCompositeReporter` (6fd65356f7) out of the Addin meant that `on run start` and `on run end` were no longer being called. This meant that the `TestRunner` GUI didn't update properly with timings, tree view, etc. This issue is not yet in a versioned release so no changelog entry is necessary.

## Contributing

- [x] I have read and agree to the [Contributor Agreement](https://github.com/sassoftware/jsl-hamcrest/blob/master/ContributorAgreement.txt)

Signed-off-by: Evan McCorkle <Evan.McCorkle@jmp.com>
