### PR TITLE
Add localization support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project will be documented in this file.
 
 ## [HEAD]
 
+### Added
+
+- `ut localized` to enable localizing content using an associative array and language codes.
+
+### Changed
+
+- Convenience `ut throws` helper functions now use `ut localize` to assert using the current languages error message.
+
 ## [1.2.0]
 
 ### Added

--- a/Source/Core/Utils.jsl
+++ b/Source/Core/Utils.jsl
@@ -694,6 +694,25 @@ ut delete symbols difference = Function({before, after, closeWindows=0},
 	::ut nullptr;
 );
 
+// Variable: ut lang
+// Code for the current language (en, de, es, fr, it, ja, ko, zh-CN)
+ut lang = System Service(Get Language Code);
+
+/*	Function: ut localize
+		Returns a string from the input associative array
+		based on the current language code
+*/
+ut localize = Function({aa, lang = ut lang},
+	If(!(aa << Contains(lang)), 
+		If(aa << Contains("en"), 
+			lang = "en",
+			Throw(EvalInsert("\[Language "^lang^" ^If(lang != "en", "and \!"en\!" ", "")^not found in ^aa^]\"))
+		)
+	);
+	
+	aa[lang];
+);
+
 /*	Function: ut include jsl files recursively
 		Looks for files in a folder recursively
 		and uses the Include() function to

--- a/Source/Core/Utils.jsl
+++ b/Source/Core/Utils.jsl
@@ -695,8 +695,8 @@ ut delete symbols difference = Function({before, after, closeWindows=0},
 );
 
 // Variable: ut lang
-// Code for the current language (en, de, es, fr, it, ja, ko, zh-CN)
-ut lang = System Service(Get Language Code);
+// Expression to get the code for the current language (en, de, es, fr, it, ja, ko, zh-CN)
+ut lang = Expr(System Service(Get Language Code));
 
 /*	Function: ut localize
 		Returns a string from the input associative array

--- a/Source/Core/Utils.jsl
+++ b/Source/Core/Utils.jsl
@@ -699,8 +699,20 @@ ut delete symbols difference = Function({before, after, closeWindows=0},
 ut lang = Expr(System Service(Get Language Code));
 
 /*	Function: ut localize
+	---Prototype---
+	ut localize( AssociativeArray aa, String lang ) 
+	---------------
 		Returns a string from the input associative array
 		based on the current language code
+	
+	Arguments:
+		aa - associative array with mappings from language code to value.
+		lang - language code to get. defaults to current language code.
+	
+	Example:
+	---JSL---
+	ut localize(["en" => "Hello", "es" => "Hola"]);
+	---------
 */
 ut localize = Function({aa, lang = ut lang},
 	If(!(aa << Contains(lang)), 

--- a/Source/Matchers/Throws.jsl
+++ b/Source/Matchers/Throws.jsl
@@ -1,4 +1,4 @@
-// Copyright © 2019, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
+﻿// Copyright © 2019, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 Names Default To Here( 0 );
@@ -77,7 +77,16 @@ ut matcher factory(
 ut matcher factory( 
 	"ut throws invalid arg",
 	Expr(Function({},
-		New Object( UtThrowsMatcher( ut equal to( "argument value is invalid" ) ) )
+		New Object( UtThrowsMatcher( ut equal to( 
+			ut localize(["en" => "argument value is invalid", 
+						 "de" => "Argumentwert ist ungültig", 
+						 "es" => "El valor del argumento no es válido.",
+						 "fr" => "la valeur de l'argument est incorrecte",
+						 "it" => "il valore dell'argomento non è valido",
+						 "ja" => "引数の値が無効です。。",
+						 "ko" => "인수 값이 올바르지 않습니다.",
+						 "zh-CN" => "参数值无效"])
+		)))
 	)),
 	"ut throws invalid arg()",
 	"\[Equivalent to ut throws( "argument value is invalid" )]\"
@@ -95,7 +104,16 @@ ut matcher factory(
 ut matcher factory( 
 	"ut throws too many args",
 	Expr(Function({},
-		New Object( UtThrowsMatcher( ut equal to( "too many arguments" ) ) )
+		New Object( UtThrowsMatcher( ut equal to( 
+			ut localize(["en" => "too many arguments", 
+						 "de" => "Zu viele Argumente", 
+						 "es" => "demasiados argumentos",
+						 "fr" => "trop d'arguments",
+						 "it" => "troppi argomenti",
+						 "ja" => "引数が多すぎます。",
+						 "ko" => "인수가 너무 많습니다.",
+						 "zh-CN" => "参数过多"])
+		)))
 	)),
 	"ut throws too many args()",
 	"\[Equivalent to ut throws( "too many arguments" )]\"
@@ -113,7 +131,16 @@ ut matcher factory(
 ut matcher factory( 
 	"ut throws name unresolved",
 	Expr(Function({var},
-		New Object( UtThrowsMatcher( ut equal to( "Name Unresolved: " || var ) ) )
+		New Object( UtThrowsMatcher( ut equal to( 
+			ut localize(["en" => "Name Unresolved: ", 
+						 "de" => "Name nicht aufgelöst: ", 
+						 "es" => "No se puede resolver el nombre: ",
+						 "fr" => "Nom non résolu : ",
+						 "it" => "Nome non risolto: ",
+						 "ja" => "名前が解決できません: ",
+						 "ko" => "확인되지 않은 이름: ",
+						 "zh-CN" => "未解析名称: "]) || var
+		)))
 	)),
 	"ut throws name unresolved( variable name )",
 	"\[Equivalent to ut throws( "Name Unresolved: var" )]\",

--- a/Source/Matchers/Throws.jsl
+++ b/Source/Matchers/Throws.jsl
@@ -83,7 +83,7 @@ ut matcher factory(
 						 "es" => "El valor del argumento no es válido.",
 						 "fr" => "la valeur de l'argument est incorrecte",
 						 "it" => "il valore dell'argomento non è valido",
-						 "ja" => "引数の値が無効です。。",
+						 "ja" => "引数の値が無効です。",
 						 "ko" => "인수 값이 올바르지 않습니다.",
 						 "zh-CN" => "参数值无效"])
 		)))

--- a/Tests/UnitTests/Matchers/XmlTest.jsl
+++ b/Tests/UnitTests/Matchers/XmlTest.jsl
@@ -18,13 +18,35 @@ ut test( ValidXmlMatcher, "Describe", Expr(
 ut test( ValidXmlMatcher, "ClosingWithoutOpeningIsDetected", Expr(
 	mi = m << Matches("<foo></bar>");
 	ut assert that( Expr( mi:success ), 0);
-	ut assert that( Expr( mi:mismatch ), ut ignoring whitespace("was invalid with Invalid XML: Non-matching end tag encountered."));
+	ut assert that( Expr( mi:mismatch ), 
+		ut ignoring whitespace("was invalid with " || 
+			ut localize(["en" => "Invalid XML: Non-matching end tag encountered.",
+					     "de" => "XML ungültig: Nicht übereinstimmendes Ende-Tag.",
+					     "es" => "XML no válido: Se ha encontrado una etiqueta final no coincidente.",
+					     "fr" => "XML incorrect : Balise de fin incohérente détectée.",
+					     "it" => "XML non valido: Trovato tag finale non corrispondente.",
+					     "ja" => "無効なXML: 終了タグがマッチしません。",
+					     "ko" => "올바르지 않은 XML: 매칭되지 않는 종료 태그가 있습니다.",
+					     "zh-CN" => "无效的 XML: 遇到不匹配项结束标记。"])
+		)			     	
+	);
 ));
 
 ut test( ValidXmlMatcher, "MalformedAttributeIsDetected", Expr(
 	mi = m << Matches("<foo a></foo>");
 	ut assert that( Expr( mi:success ), 0);
-	ut assert that( Expr( mi:mismatch ), ut ignoring whitespace("was invalid with Invalid XML: Missing \!"=\!"."));
+	ut assert that( Expr( mi:mismatch ), 
+		ut ignoring whitespace("was invalid with " || 
+			ut localize(["en" => "Invalid XML: Missing \!"=\!".",
+					     "de" => "XML ungültig: „=“ fehlt.",
+					     "es" => "XML no válido: Falta \!"=\!".",
+					     "fr" => "XML incorrect : \!"=\!" manquant.",
+					     "it" => "XML non valido: \!"=\!" mancante.",
+					     "ja" => "無効なXML: \!"=\!"がありません。",
+					     "ko" => "올바르지 않은 XML: \!"=\!"가 없습니다.",
+					     "zh-CN" => "无效的 XML: 缺失“=”。"])
+		)			     	
+	);
 ));
 
 ut test( ValidXmlMatcher, "XmlCanHaveAttributes", Expr(

--- a/Tests/UnitTests/UtilsTests.jsl
+++ b/Tests/UnitTests/UtilsTests.jsl
@@ -123,10 +123,10 @@ ut test( "Utils", "DeleteSymbolsDifferenceDeletesNamespaces", Expr(
 
 UtilsLocalizeTests = ut test case("UtilsLocalize")
 	<<Setup(Expr(
-		lang = ut lang;
+		lang = Name Expr(ut lang);
 		aa = ["en" => "Hello", "es" => "Hola"];
 	))
-	<<Teardown(Expr(ut lang = lang));
+	<<Teardown(Expr(ut lang = Name Expr(lang)));
 
 ut test( UtilsLocalizeTests, "ut lang", Expr(
     ut lang = "en";

--- a/Tests/UnitTests/UtilsTests.jsl
+++ b/Tests/UnitTests/UtilsTests.jsl
@@ -121,12 +121,29 @@ ut test( "Utils", "DeleteSymbolsDifferenceDeletesNamespaces", Expr(
     ut assert that( Expr( after delete["namespaces"] ), ut not( ut contains( ns << Get Name ) ) );
 ));
 
-ut test( "Utils", "Localize", Expr(
-	aa = ["en" => "Hello", "es" => "Hola"];
-    ut assert that( Expr( ut localize(aa, "en") ), "Hello");
+UtilsLocalizeTests = ut test case("UtilsLocalize")
+	<<Setup(Expr(
+		lang = ut lang;
+		aa = ["en" => "Hello", "es" => "Hola"];
+	))
+	<<Teardown(Expr(ut lang = lang));
+
+ut test( UtilsLocalizeTests, "ut lang", Expr(
+    ut lang = "en";
+    ut assert that( Expr( ut localize(aa) ), "Hello");
+    ut lang = "es";
+    ut assert that( Expr( ut localize(aa) ), "Hola");
+    ut lang = "fr";
+    ut assert that( Expr( ut localize(aa) ), "Hello");
+));
+
+ut test( UtilsLocalizeTests, "lang arg", Expr(
+    ut assert that( Expr( ut localize(aa, "en") ), "Hello"); 
     ut assert that( Expr( ut localize(aa, "es") ), "Hola");
     ut assert that( Expr( ut localize(aa, "fr") ), "Hello");
+));
+
+ut test( "UtilsLocalize", "not found error", Expr(
     ut assert that( Expr( ut localize([=>], "en") ), ut throws("\[Language "en" not found in [=>]]\"));
     ut assert that( Expr( ut localize([=>], "fr") ), ut throws("\[Language "fr" and "en" not found in [=>]]\"));
 ));
-

--- a/Tests/UnitTests/UtilsTests.jsl
+++ b/Tests/UnitTests/UtilsTests.jsl
@@ -120,3 +120,13 @@ ut test( "Utils", "DeleteSymbolsDifferenceDeletesNamespaces", Expr(
     after delete = ut get symbol information();
     ut assert that( Expr( after delete["namespaces"] ), ut not( ut contains( ns << Get Name ) ) );
 ));
+
+ut test( "Utils", "Localize", Expr(
+	aa = ["en" => "Hello", "es" => "Hola"];
+    ut assert that( Expr( ut localize(aa, "en") ), "Hello");
+    ut assert that( Expr( ut localize(aa, "es") ), "Hola");
+    ut assert that( Expr( ut localize(aa, "fr") ), "Hello");
+    ut assert that( Expr( ut localize([=>], "en") ), ut throws("\[Language "en" not found in [=>]]\"));
+    ut assert that( Expr( ut localize([=>], "fr") ), ut throws("\[Language "fr" and "en" not found in [=>]]\"));
+));
+


### PR DESCRIPTION
Adds localization function `ut localize` to turn an associative array into a string based on the current language code. Used this support in functions like `ut throws name unresolved` and updated existing tests that failed in other languages.

## Checklist
- [x] **I am adding new or changing current functionality.**
  - [x] I have added or updated the tests for the new or changed functionality in `Tests/UnitTests`.
  - [x] I have added note(s) to `CHANGELOG.md` as necessary.

## Contributing

- [x] I have read and agree to the [Contributor Agreement](https://github.com/sassoftware/jsl-hamcrest/blob/master/ContributorAgreement.txt)

<!--- Replace your name and e-mail below -->
Signed-off-by: Justin Chilton <justin.chilton@jmp.com>
