### PR TITLE
Fix FileAppendingReporter tests

### DIFF
--- a/Tests/UnitTests/Reporters/FileAppendingReporterTest.jsl
+++ b/Tests/UnitTests/Reporters/FileAppendingReporterTest.jsl
@@ -2,7 +2,7 @@
 FileAppendingReporterTests = ut test case("FileAppendingReporter") 
   <<Setup(Expr(
     reporter path = "$temp/fileAppendingReporter.txt";
-    Delete File(reporter path);
+    Try(Delete File(reporter path));
     reporter = ut file appending reporter(reporter path);
   ));
 


### PR DESCRIPTION
Adds a `Try()` around `Delete File()` which was failing when the file did not already exist.

## Contributing

- [x] I have read and agree to the [Contributor Agreement](https://github.com/sassoftware/jsl-hamcrest/blob/master/ContributorAgreement.txt)

Signed-off-by: Justin Chilton <justin.chilton@jmp.com>
