### PR TITLE
Avoid collision with builtin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 
 ## [HEAD]
 
+### Changed
+
+- Avoid potential collision with builtin functions in `UtSizeMatcher` (#109)
+
 ## [1.2.0]
 
 ### Added

--- a/Source/Matchers/Size.jsl
+++ b/Source/Matchers/Size.jsl
@@ -18,7 +18,7 @@ Define Class(
 	transform description = "";
 	_init_ = Method( {inner, transform function, transform description},
 		this:inner = inner;
-		this:transform function = Parse( transform function );
+		this:transform function = Parse( "Builtin:" || transform function );
 		this:transform description = transform description;
 	);
 	matches = Method( {test expr},

--- a/Tests/UnitTests/Matchers/SizeTest.jsl
+++ b/Tests/UnitTests/Matchers/SizeTest.jsl
@@ -1,0 +1,6 @@
+
+ut test("SizeTests", "Avoids name collisions", Expr(
+	dt = New Table("A Table", Add Rows(1));
+	n rows = 5;
+	ut assert that(Expr(dt), ut n rows(1));
+));


### PR DESCRIPTION
Variables and column names could collide with functions used by the `UtSizeMatcher`, including `N Rows`, `N Cols`, `N Items`, etc.

## Description
This adds `Builtin:` prefix to the function calls so there is no ambiguity to which function we are trying to use.

## Checklist
- [x] **I am adding new or changing current functionality.**
  - [x] I have added or updated the tests for the new or changed functionality in `Tests/UnitTests`.
  - [x] I have added note(s) to `CHANGELOG.md` as necessary.

## Contributing

- [x] I have read and agree to the [Contributor Agreement](https://github.com/sassoftware/jsl-hamcrest/blob/master/ContributorAgreement.txt)

<!--- Replace your name and e-mail below -->
Signed-off-by: Justin Chilton <justin.chilton@jmp.com>
