### PR TITLE
JunitXMLReporter improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Convenience `ut throws` helper functions now use `ut localize` to assert using the current languages error message.
+- `UtJunitXMLReporter` reports file and classname attributes for testcases and treats throws differently from failures.
 
 ## [1.2.0]
 

--- a/Source/Reporters/JunitXMLReporter.jsl
+++ b/Source/Reporters/JunitXMLReporter.jsl
@@ -33,7 +33,104 @@ Example of JunitXML format:
 
 Define Class(
   "UtJunitXMLReporter",
-  Base Class( UtCollectingReporter ),
+  Base Class( "UtReporter" ),
+
+  // Variable: hash_results
+  // associative array of the test results
+  // test suite => test case => successes, failures, throws
+  hash_results = [=>Associative Array()];
+
+  // Variable: n successes
+  n successes = 0;
+
+  // Variable: n failures
+  n failures = 0;
+
+  // Variable: n unexpected throws
+  n unexpected throws = 0;
+
+  /*
+  Method: add to hash
+
+  ---Prototype---
+  add to hash(curr_suite, curr_test, result)
+  ---------------
+  Adds the result of a test to hash_results
+
+  Arguments:
+    curr_suite - the name of the test suite
+    curr_test - the name of the test
+    result - the result of the test
+  */
+  add to hash = Method({curr_suite, curr_test, result},
+    If(Contains(this:hash_results << get keys, curr_suite),
+      If(Contains(this:hash_results[curr_suite] << get keys, curr_test),
+        Insert Into(this:hash_results[curr_suite][curr_test], result);
+        ,
+        this:hash_results[curr_suite][curr_test] = Eval List({result});
+      )
+      ,
+      result_list = Eval List({result});
+      this:hash_results[curr_suite] = Associative Array(Eval List({curr_test}), Eval List({result_list}));
+    );
+  );
+
+  // Function: add expression failure
+  add expression failure = Method( {label, payload=Empty()},
+      add failure( label, "test expr", "is an expression", "was not an expression", Empty(), Name Expr( payload ) );
+  );
+
+  // Function: add failure
+  add failure = Method( {label, test expr, description, mismatch, lre, payload=Empty()},
+    char test expr = If( Is Expr( Name Expr( test expr ) ),
+      Char( Name Expr( test expr ) ),
+      Char( test expr )
+    ) || " ";
+
+    parsed_label = this:parse_label(label);
+    curr_suite = parsed_label[1];
+    curr_test = parsed_label[2];
+    fail_msg = "Expected: " || char test expr || description || "\!n";
+    fail_msg ||= "But: " || mismatch || "\!n" ;
+    fail_msg = Trim(fail_msg);
+    fail_hash = Associative Array(Eval List({"failure"}), Eval List({fail_msg}));
+    this:add to hash(curr_suite, curr_test, fail_hash);
+    this:n failures++;
+    0;
+  );
+
+  // Function: add unexpected throw
+  add unexpected throw = Method( {label, test expr, description, exception, payload=Empty()},
+    char test expr = If( Is Expr( Name Expr( test expr ) ),
+      Char( Name Expr( test expr ) ),
+      Char( test expr )
+    ) || " ";
+    parsed_label = this:parse_label(label);
+    curr_suite = parsed_label[1];
+    curr_test = parsed_label[2];
+    throw_msg = "  Expected: " || char test expr || description || "\!n";
+    If( Is Empty( exception ),
+      throw_msg ||= "But: " || "unexpectedly threw nothing\!n",
+      throw_msg ||= "But: " || "unexpectedly threw \!"" || exception || "\!"\!n";
+    );
+    throw_msg = Trim(throw_msg);
+    throw_hash = Associative Array(Eval List({"failure"}), Eval List({throw_msg}));
+    this:add to hash(curr_suite, curr_test, throw_hash);
+    this:n unexpected throws++;
+    0;
+  );
+
+  // Function: add success
+  add success = Method( {label, test expr, description, payload=Empty()},
+    parsed_label = this:parse_label(label);
+    curr_suite = parsed_label[1];
+    curr_test = parsed_label[2];
+    // empty for a success
+    success_hash = Associative Array();
+    this:add to hash(curr_suite, curr_test, success_hash);
+    this:n successes++;
+    1;
+  );
 
   /*
   Method: generate_xml_tag
@@ -175,8 +272,8 @@ Define Class(
     props = Associative Array();
     date = today();
     props["id"] = format(date, "yyyymmdd" ) || "_" || Char(Hour(date)) || Char(Minute(date)) || Char(Second(date));
-    props["tests"] = Char(Nitems(this:successes) + NItems(this:failures) + NItems(this:unexpected throws));
-    props["failures"] = Char(NItems(this:failures) + NItems(this:unexpected throws));
+    props["tests"] = Char(this:n successes + this:n failures + this:n unexpected throws);
+    props["failures"] = Char(this:n failures + this:n unexpected throws);
 
     xml_result = start_line || this:generate_xml_tag("testsuites", trim(content), props, 0);
     Return(xml_result);
@@ -188,16 +285,14 @@ Define Class(
   //
   // Arguments: 
   //  label - A label separated by a separator
-  //  hash_results - Associative Array with test suites as keys and associative arrays with test cases as keys as values
   // 
   // Results:
   //  The label split by the separator. The second and third values will be joined by an _
   //  The first element will be the suite name and the second will be the test name
   //  If the given label is "", current suite is named "Anonymous_Test_Suite",
   //  and the test will be the given label or "Anonymous_Test_Name"
-  //  with one higher than the latest number found in the hash_results
 
-  parse_label = Method({label, hash_results},
+  parse_label = Method({label},
     list_label = words(label, ::ut concat test label sep);
 
     // set to anonymous test name if missing
@@ -216,104 +311,18 @@ Define Class(
       1,
       curr_suite = "Anonymous_Test_Suite";
       curr_test = list_label[1];
-
-      // need to increase the number
-      anonymous_test_suite = hash_results["Anonymous_Test_Suite"];
-      anonymous_test_cases = anonymous_test_suite << get keys;
     );
     Return(Eval List(List(curr_suite, curr_test)));
   );
-  
+
   // Method: get report
   //
   // Get a report detailing all the successes and
   // failures for each test in JunitXML format shown in the comments at the top.
   get report = Method( {},
-    num successes = Length( this:successes );
-    num failures = Length( this:failures );
-    num unexpected throws = Length( this:unexpected throws );
-    hash_results = [=>Associative Array()];
-
-    For( i = 1, i <= num successes, i++,
-      char test expr = If( Is Expr( Name Expr( this:successes[i][2] ) ),
-        Char( Name Expr( this:successes[i][2] ) ),
-        Char( this:successes[i][2] )
-      ) || " ";
-      parsed_label = this:parse_label(this:successes[i][1], hash_results);
-      curr_suite = parsed_label [1];
-      curr_test = parsed_label[2];
-      // empty for a success
-      success_hash = Associative Array();
-      If(Contains(hash_results << get keys, curr_suite),
-        If(Contains(hash_results[curr_suite] << get keys, curr_test),
-          Insert Into(hash_results[curr_suite][curr_test], success_hash);
-          ,
-          hash_results[curr_suite][curr_test] = Eval List({success_hash});
-        )
-        ,
-        success_hash_list = Eval List({success_hash});
-        hash_results[curr_suite] = Associative Array(Eval List({curr_test}), Eval List({success_hash_list}));
-      );
-    );
-
-    // associative array of the test results
-    // test suite => test case => successes, failures, throws
-    
-    For( i = 1, i <= num failures, i++,
-      char test expr = If( Is Expr( Name Expr( this:failures[i][2] ) ),
-        Char( Name Expr( this:failures[i][2] ) ),
-        Char( this:failures[i][2] )
-      ) || " ";
-
-      parsed_label = this:parse_label(this:failures[i][1], hash_results);
-      curr_suite = parsed_label [1];
-      curr_test = parsed_label[2];
-      fail_msg = "Expected: " || char test expr || this:failures[i][3] || "\!n";
-      fail_msg ||= "But: " || this:failures[i][4] || "\!n" ;
-      fail_msg = Trim(fail_msg);
-      fail_hash = Associative Array(Eval List({"failure"}), Eval List({fail_msg}));
-      If(Contains(hash_results << get keys, curr_suite),
-        If(Contains(hash_results[curr_suite] << get keys, curr_test),
-          Insert Into(hash_results[curr_suite][curr_test], fail_hash);
-          ,
-          hash_results[curr_suite][curr_test] = Eval List({fail_hash});
-        )
-        ,
-        fail_hash_list = Eval List({fail_hash});
-        hash_results[curr_suite] = Associative Array(Eval List({curr_test}), Eval List({fail_hash_list}));
-      );
-    );
-
-    For( i = 1, i <= num unexpected throws, i++,
-      char test expr = If( Is Expr( Name Expr( this:unexpected throws[i][2] ) ),
-        Char( Name Expr( this:unexpected throws[i][2] ) ),
-        Char( this:unexpected throws[i][2] )
-      ) || " ";
-      parsed_label = this:parse_label(this:unexpected throws[i][1], hash_results);
-      curr_suite = parsed_label [1];
-      curr_test = parsed_label[2];
-      throw_msg = "  Expected: " || char test expr || this:unexpected throws[i][3] || "\!n";
-      If( Is Empty( this:unexpected throws[i][4] ),
-        throw_msg ||= "But: " || "unexpectedly threw nothing\!n",
-        throw_msg ||= "But: " || "unexpectedly threw \!"" || this:unexpected throws[i][4] || "\!"\!n";
-      );
-      throw_msg = Trim(throw_msg);
-      throw_hash = Associative Array(Eval List({"failure"}), Eval List({throw_msg}));
-      If(Contains(hash_results << get keys, curr_suite),
-        If(Contains(hash_results[curr_suite] << get keys, curr_test),
-          Insert Into(hash_results[curr_suite][curr_test], throw_hash);
-          ,
-          hash_results[curr_suite][curr_test] = Eval List({throw_hash});
-        )
-        ,
-        throw_hash_list = Eval List({ throw_hash});
-        hash_results[curr_suite] = Associative Array(Eval List({curr_test}), Eval List({ throw_hash_list}));
-      );
-
-    );
-    this:get_xml_report(hash_results);
+    this:get_xml_report(this:hash_results)
   );
-  
+
   // Method: show report
   //
   // Dump a report to the log detailing all the successes and

--- a/Source/Reporters/JunitXMLReporter.jsl
+++ b/Source/Reporters/JunitXMLReporter.jsl
@@ -86,7 +86,7 @@ Define Class(
       Char( Name Expr( test expr ) ),
       Char( test expr )
     ) || " ";
-
+    file_name = Word( -1, Include File List()[1], "/\"); // TODO: get file name relative to some base directory (optional)
     parsed_label = this:parse_label(label);
     curr_suite = parsed_label[1];
     curr_test = parsed_label[2];
@@ -94,6 +94,7 @@ Define Class(
     fail_msg ||= "But: " || mismatch || "\!n" ;
     fail_msg = Trim(fail_msg);
     fail_hash = Associative Array(Eval List({"failure"}), Eval List({fail_msg}));
+    fail_hash["@file"] = file_name;
     this:add to hash(curr_suite, curr_test, fail_hash);
     this:n failures++;
     0;
@@ -105,6 +106,7 @@ Define Class(
       Char( Name Expr( test expr ) ),
       Char( test expr )
     ) || " ";
+    file_name = Word( -1, Include File List()[1], "/\");
     parsed_label = this:parse_label(label);
     curr_suite = parsed_label[1];
     curr_test = parsed_label[2];
@@ -115,6 +117,7 @@ Define Class(
     );
     throw_msg = Trim(throw_msg);
     throw_hash = Associative Array(Eval List({"failure"}), Eval List({throw_msg}));
+    throw_hash["@file"] = file_name;
     this:add to hash(curr_suite, curr_test, throw_hash);
     this:n unexpected throws++;
     0;
@@ -122,11 +125,13 @@ Define Class(
 
   // Function: add success
   add success = Method( {label, test expr, description, payload=Empty()},
+    file_name = Word( -1, Include File List()[1], "/\");
     parsed_label = this:parse_label(label);
     curr_suite = parsed_label[1];
     curr_test = parsed_label[2];
     // empty for a success
     success_hash = Associative Array();
+    success_hash["@file"] = file_name;
     this:add to hash(curr_suite, curr_test, success_hash);
     this:n successes++;
     1;
@@ -238,27 +243,27 @@ Define Class(
       num_successes = 0;
       For(k=1, k<=NItems(test_case_names), k++,
 
-        info_types = test_case_info[k] << get keys;
-        
         test_case_content = "";
         For(l=1, l<=NItems(test_case_info[k]), l++,
           num_tests += 1;
-          info_types = test_case_info[k][l] << get keys;
-          // case for a success
-          If(Nitems(info_types) == 0,
+          results = test_case_info[k][l];
+          // TODO: add error case
+          If(contains(results, "failure"),
+            result = "failure"
+          , // case for a success
             num_successes += 1;
             Continue();
           );
-          info_type = info_types[1];
           props = Associative Array();
-          props["type"] = info_type;
-          failure_content = this:generate_xml_tag("failure", test_case_info[k][l][info_type], props);
+          props["type"] = result; // TODO: should be type of assert/ type of error
+          failure_content = this:generate_xml_tag(result, test_case_info[k][l][result], props);
           test_case_content ||= failure_content;
 
         );
         props = Associative Array();
         props["classname"] = test_suites[i];
         props["name"] = test_case_names[k];
+        props["file"] = test_case_info[k][1]["@file"]; // File is same across asserts so get 1st one
         test_case_xml ||= this:generate_xml_tag("testcase", trim(test_case_content), props, 0);
         
       );

--- a/Source/Reporters/JunitXMLReporter.jsl
+++ b/Source/Reporters/JunitXMLReporter.jsl
@@ -107,10 +107,7 @@ Define Class(
     dirs = Words( full path, "/\");
     path start = Contains( dirs, this:base dir );
     If( path start,
-      path = dirs[path start];
-      For( i = path start + 1, i <= NItems(dirs), i++,
-        path ||= "/" || dirs[i]
-      );
+      Return( Concat Items( dirs[path start::NItems(dirs)], "/" ) );
       Return( path );
     ,
       Return( Word( -1, full path, "/\" ) );

--- a/Source/Reporters/JunitXMLReporter.jsl
+++ b/Source/Reporters/JunitXMLReporter.jsl
@@ -100,6 +100,9 @@ Define Class(
   The path will be relative to the base dir if provided.
   */
   get file path = Method( {},
+    If( Include File List()[1] == "",
+      Return("")
+    );
     full path = Convert File Path( Include File List()[1] );
     If( this:base dir == "/" | this:base dir == "\",
       Return(full path)

--- a/Source/Reporters/JunitXMLReporter.jsl
+++ b/Source/Reporters/JunitXMLReporter.jsl
@@ -52,8 +52,10 @@ Define Class(
   base dir = "";
 
   _init_ = Method({base dir},
-    
-    this:base dir = If( length(base dir) != 1,
+    If( NItems( Words(base dir, "/\") ) > 1,
+      Throw( "UtJunitXMLReporter requires base dir to be a single directory's name." );
+    );
+    this:base dir = If( Length(base dir) != 1,
                         // Remove any separators
                         Substitute( base dir, "\", "", "/", "" )
                       , // special case for "/" or "\" to get a full path

--- a/Source/Reporters/JunitXMLReporter.jsl
+++ b/Source/Reporters/JunitXMLReporter.jsl
@@ -277,7 +277,8 @@ Define Class(
       test_case_info = test_cases << get values;
       test_case_xml = "";
       num_tests = 0;
-      num_successes = 0;
+      num_failures = 0;
+      num_errors = 0;
       For(k=1, k<=NItems(test_case_names), k++,
 
         test_case_content = "";
@@ -286,10 +287,11 @@ Define Class(
           results = test_case_info[k][l];
           If( Contains( results, "failure" ),
               result = "failure";
+              num_failures += 1
           , Contains( results, "error" ),
               result = "error";
+              num_errors += 1
           , // case for a success
-              num_successes += 1;
               Continue();
           );
           props = Associative Array();
@@ -308,7 +310,8 @@ Define Class(
       props = Associative Array();
       props["name"] = test_suites[i];
       props["tests"] = Char(num_tests);
-      props["failures"] = Char(num_tests-num_successes);
+      props["failures"] = Char(num_failures);
+      props["errors"] = Char(num_errors);
       test_suite_tag = this:generate_xml_tag("testsuite", trim(test_case_xml), props, 0);
       content ||= test_suite_tag;
     );
@@ -317,7 +320,8 @@ Define Class(
     date = today();
     props["id"] = format(date, "yyyymmdd" ) || "_" || Char(Hour(date)) || Char(Minute(date)) || Char(Second(date));
     props["tests"] = Char(this:n successes + this:n failures + this:n unexpected throws);
-    props["failures"] = Char(this:n failures + this:n unexpected throws);
+    props["failures"] = Char(this:n failures);
+    props["errors"] = Char(this:n unexpected throws);
 
     xml_result = start_line || this:generate_xml_tag("testsuites", trim(content), props, 0);
     Return(xml_result);

--- a/Source/Reporters/JunitXMLReporter.jsl
+++ b/Source/Reporters/JunitXMLReporter.jsl
@@ -257,6 +257,7 @@ Define Class(
 
         );
         props = Associative Array();
+        props["classname"] = test_suites[i];
         props["name"] = test_case_names[k];
         test_case_xml ||= this:generate_xml_tag("testcase", trim(test_case_content), props, 0);
         

--- a/Source/Reporters/JunitXMLReporter.jsl
+++ b/Source/Reporters/JunitXMLReporter.jsl
@@ -49,6 +49,19 @@ Define Class(
   // Variable: n unexpected throws
   n unexpected throws = 0;
 
+  base dir = "";
+
+  _init_ = Method({base dir},
+    
+    this:base dir = If( length(base dir) != 1,
+                        // Remove any separators
+                        Substitute( base dir, "\", "", "/", "" )
+                      , // special case for "/" or "\" to get a full path
+                        base dir
+                    );
+
+  );
+
   /*
   Method: add to hash
 
@@ -75,6 +88,33 @@ Define Class(
     );
   );
 
+  /*
+  Method: get file path
+
+  ---Prototype---
+  get file path()
+  ---------------
+  Gets the file path that the test came from.
+  The path will be relative to the base dir if provided.
+  */
+  get file path = Method( {},
+    full path = Convert File Path( Include File List()[1] );
+    If( this:base dir == "/" | this:base dir == "\",
+      Return(full path)
+    );
+    dirs = Words( full path, "/\");
+    path start = Contains( dirs, this:base dir );
+    If( path start,
+      path = dirs[path start];
+      For( i = path start + 1, i <= NItems(dirs), i++,
+        path ||= "/" || dirs[i]
+      );
+      Return( path );
+    ,
+      Return( Word( -1, full path, "/\" ) );
+    );
+  );
+
   // Function: add expression failure
   add expression failure = Method( {label, payload=Empty()},
       add failure( label, "test expr", "is an expression", "was not an expression", Empty(), Name Expr( payload ) );
@@ -86,7 +126,6 @@ Define Class(
       Char( Name Expr( test expr ) ),
       Char( test expr )
     ) || " ";
-    file_name = Word( -1, Include File List()[1], "/\"); // TODO: get file name relative to some base directory (optional)
     parsed_label = this:parse_label(label);
     curr_suite = parsed_label[1];
     curr_test = parsed_label[2];
@@ -94,7 +133,7 @@ Define Class(
     fail_msg ||= "But: " || mismatch || "\!n" ;
     fail_msg = Trim(fail_msg);
     fail_hash = Associative Array(Eval List({"failure"}), Eval List({fail_msg}));
-    fail_hash["@file"] = file_name;
+    fail_hash["@file"] = get file path();
     this:add to hash(curr_suite, curr_test, fail_hash);
     this:n failures++;
     0;
@@ -106,7 +145,6 @@ Define Class(
       Char( Name Expr( test expr ) ),
       Char( test expr )
     ) || " ";
-    file_name = Word( -1, Include File List()[1], "/\");
     parsed_label = this:parse_label(label);
     curr_suite = parsed_label[1];
     curr_test = parsed_label[2];
@@ -117,7 +155,7 @@ Define Class(
     );
     throw_msg = Trim(throw_msg);
     throw_hash = Associative Array(Eval List({"failure"}), Eval List({throw_msg}));
-    throw_hash["@file"] = file_name;
+    throw_hash["@file"] = get file path();
     this:add to hash(curr_suite, curr_test, throw_hash);
     this:n unexpected throws++;
     0;
@@ -125,13 +163,12 @@ Define Class(
 
   // Function: add success
   add success = Method( {label, test expr, description, payload=Empty()},
-    file_name = Word( -1, Include File List()[1], "/\");
     parsed_label = this:parse_label(label);
     curr_suite = parsed_label[1];
     curr_test = parsed_label[2];
     // empty for a success
     success_hash = Associative Array();
-    success_hash["@file"] = file_name;
+    success_hash["@file"] = get file path();
     this:add to hash(curr_suite, curr_test, success_hash);
     this:n successes++;
     1;
@@ -338,8 +375,22 @@ Define Class(
   );
 );
 
-// Function: ut JunitXML reporter
-//  Factory for <UtJunitXMLReporter>.
-ut junit xml reporter = Function({},
-  New Object( "UtJunitXMLReporter" );
+/*  Function: ut junit xml reporter
+      Reporter which appends failures as they happen to an output file.
+
+      Factory for <UtJUnitXMLReporter>.
+
+    Arguments:
+      base dir - Directory that the test file names will be relative to
+                 in the file attribute of testcase tags.
+
+    Example:
+    With test files in test/A/ and test/B/
+    ---JSL---
+    ut global reporter = ut junit xml reporter( "test/" );
+    ---------
+    will give file attributes like "test/A/A_test1.jsl", "test/B/B_test1.jsl", etc.
+*/
+ut junit xml reporter = Function({ base path="" },
+  New Object( "UtJunitXMLReporter"( base path ) );
 );

--- a/Source/Reporters/JunitXMLReporter.jsl
+++ b/Source/Reporters/JunitXMLReporter.jsl
@@ -38,7 +38,7 @@ Define Class(
   // Variable: hash_results
   // associative array of the test results
   // test suite => test case => successes, failures, throws
-  hash_results = [=>Associative Array()];
+  hash_results = [=>[=>]];
 
   // Variable: n successes
   n successes = 0;
@@ -110,10 +110,9 @@ Define Class(
     dirs = Words( full path, "/\");
     path start = Contains( dirs, this:base dir );
     If( path start,
-      Return( Concat Items( dirs[path start::NItems(dirs)], "/" ) );
-      Return( path );
+      Concat Items( dirs[path start::NItems(dirs)], "/" )
     ,
-      Return( Word( -1, full path, "/\" ) );
+      Word( -1, full path, "/\" )
     );
   );
 

--- a/Source/Reporters/JunitXMLReporter.jsl
+++ b/Source/Reporters/JunitXMLReporter.jsl
@@ -154,7 +154,7 @@ Define Class(
       throw_msg ||= "But: " || "unexpectedly threw \!"" || exception || "\!"\!n";
     );
     throw_msg = Trim(throw_msg);
-    throw_hash = Associative Array(Eval List({"failure"}), Eval List({throw_msg}));
+    throw_hash = Associative Array(Eval List({"error"}), Eval List({throw_msg}));
     throw_hash["@file"] = get file path();
     this:add to hash(curr_suite, curr_test, throw_hash);
     this:n unexpected throws++;
@@ -284,15 +284,16 @@ Define Class(
         For(l=1, l<=NItems(test_case_info[k]), l++,
           num_tests += 1;
           results = test_case_info[k][l];
-          // TODO: add error case
-          If(contains(results, "failure"),
-            result = "failure"
+          If( Contains( results, "failure" ),
+              result = "failure";
+          , Contains( results, "error" ),
+              result = "error";
           , // case for a success
-            num_successes += 1;
-            Continue();
+              num_successes += 1;
+              Continue();
           );
           props = Associative Array();
-          props["type"] = result; // TODO: should be type of assert/ type of error
+          props["type"] = result;
           failure_content = this:generate_xml_tag(result, test_case_info[k][l][result], props);
           test_case_content ||= failure_content;
 

--- a/Tests/UnitTests/Reporters/JunitXMLReporterTest.jsl
+++ b/Tests/UnitTests/Reporters/JunitXMLReporterTest.jsl
@@ -31,6 +31,11 @@ n root failures = Function({xml}, {out = .},
 	local:out
 );
 
+n root errors = Function({xml}, {out = .},
+	Parse XML(xml, On Element("testsuites", Start Tag(local:out = Num(Xml Attr("errors")))));
+	local:out
+);
+
 suite names = Function({xml}, {out = {}},
 	Parse XML(xml, On Element("testsuite", Start Tag(Insert Into(local:out, Xml Attr("name")))));
 	local:out
@@ -131,12 +136,13 @@ ut test(JunitXMLReporters, "Counts are correct at root", Expr(
 		));
 		ut test("B", "b", Expr(
 			ut assert value(7, 7);
-			ut assert value(8, 0);
+			ut assert value(8 + "a", 0);
 		));
 	));
 
 	ut assert that( Expr(n root tests(report)), 8 );
-	ut assert that( Expr(n root failures(report)), 4 );
+	ut assert that( Expr(n root failures(report)), 3 );
+	ut assert that( Expr(n root errors(report)), 1 );
 	ut assert that( Expr(suite names(report)), {"A", "Anonymous_Test_Suite", "B"} );
 ));
 
@@ -151,9 +157,9 @@ ut test( JunitXMLReporters, "JunitXMLReporter one simple passing", Expr(
 	ut assert that(Expr(reporter << n successes), ut equal to (1));
 	pattern = 
 	"\[<\?xml version="1.0" encoding="UTF-8" \?>
-	<testsuites failures="0" id="\d+_\d+" tests="1">
-	  <testsuite failures="0" name="Simple Pass" tests="1">
-		<testcase name="One plus one equals two">
+	<testsuites errors="0" failures="0" id="\d+_\d+" tests="1">
+	  <testsuite errors="0" failures="0" name="Simple Pass" tests="1">
+		<testcase classname="Simple Pass" file="JunitXMLReporterTest\.jsl" name="One plus one equals two">
 		</testcase>
 	  </testsuite>
 	</testsuites>
@@ -183,9 +189,9 @@ ut test( JunitXMLReporters, "JunitXMLReporter one simple failing", Expr(
 	
 	pattern = 
 	"\[<\?xml version="1.0" encoding="UTF-8" \?>
-	<testsuites failures="1" id="\d+_\d+" tests="1">
-	  <testsuite failures="1" name="Simple Fail" tests="1">
-		<testcase name="One plus one equals one">
+	<testsuites errors="0" failures="1" id="\d+_\d+" tests="1">
+	  <testsuite errors="0" failures="1" name="Simple Fail" tests="1">
+		<testcase classname="Simple Fail" file="JunitXMLReporterTest\.jsl" name="One plus one equals one">
 		  <failure type="failure">
 			Expected: 1 \+ 1 equal to 1
 			But: was 2
@@ -216,9 +222,9 @@ ut test(JunitXMLReporters, "Assertion with 4 part label works", Expr(
 	ut assert that( Expr(report), ut valid xml() );
 	
 	pattern = "<\?xml version=\!"1.0\!" encoding=\!"UTF-8\!" \?>
-	<testsuites failures=\!"1\!" id=\!"\d+_\d+\!" tests=\!"1\!">
-	  <testsuite failures=\!"1\!" name=\!"A\!" tests=\!"1\!">
-		<testcase name=\!"a_extra info\!">
+	<testsuites errors=\!"0\!" failures=\!"1\!" id=\!"\d+_\d+\!" tests=\!"1\!">
+	  <testsuite errors=\!"0\!" failures=\!"1\!" name=\!"A\!" tests=\!"1\!">
+		<testcase classname=\!"A\!" file=\!"JunitXMLReporterTest\.jsl\!" name=\!"a_extra info\!">
 		  <failure type=\!"failure\!">
 			Expected: Expr\(1\) equal to 0
 			But: was 1
@@ -339,15 +345,15 @@ ut test(JunitXMLReporters, "Multiple successes and failure report as expected", 
 	ut assert that( Expr(report), ut valid xml() );
 	
 	pattern ="<?xml version=\!"1.0\!" encoding=\!"UTF-8\!" ?>
-	<testsuites failures=\!"6\!" id=\!"\d+_\d+\!" tests=\!"10\!">
-	  <testsuite failures=\!"4\!" name=\!"Example Tests\!" tests=\!"6\!">
-		<testcase name=\!"Test1\!">
+	<testsuites errors=\!"0\!" failures=\!"6\!" id=\!"\d+_\d+\!" tests=\!"10\!">
+	  <testsuite errors=\!"0\!" failures=\!"4\!" name=\!"Example Tests\!" tests=\!"6\!">
+		<testcase classname=\!"Example Tests\!" file=\!"JunitXMLReporterTest\.jsl\!" name=\!"Test1\!">
 		  <failure type=\!"failure\!">
 			Expected: add_nums(1, 1) equal to 3
 			But: was 2
 		  </failure>
 		</testcase>
-		<testcase name=\!"Test2\!">
+		<testcase classname=\!"Example Tests\!" file=\!"JunitXMLReporterTest\.jsl\!" name=\!"Test2\!">
 		  <failure type=\!"failure\!">
 			Expected: add_nums(3, 5) equal to 7
 			But: was 8
@@ -357,27 +363,27 @@ ut test(JunitXMLReporters, "Multiple successes and failure report as expected", 
 			But: was 8
 		  </failure>
 		</testcase>
-		<testcase name=\!"Test3\!">
+		<testcase classname=\!"Example Tests\!" file=\!"JunitXMLReporterTest\.jsl\!" name=\!"Test3\!">
 		</testcase>
-		<testcase name=\!"Test4\!">
+		<testcase classname=\!"Example Tests\!" file=\!"JunitXMLReporterTest\.jsl\!" name=\!"Test4\!">
 		  <failure type=\!"failure\!">
 			Expected: add_nums(3, 5) equal to 9
 			But: was 8
 		  </failure>
 		</testcase>
 	  </testsuite>
-	  <testsuite failures=\!"2\!" name=\!"Example Tests 2\!" tests=\!"4\!">
-		<testcase name=\!"Test1\!">
+	  <testsuite errors=\!"0\!" failures=\!"2\!" name=\!"Example Tests 2\!" tests=\!"4\!">
+		<testcase classname=\!"Example Tests 2\!" file=\!"JunitXMLReporterTest\.jsl\!" name=\!"Test1\!">
 		</testcase>
-		<testcase name=\!"Test2\!">
+		<testcase classname=\!"Example Tests 2\!" file=\!"JunitXMLReporterTest\.jsl\!" name=\!"Test2\!">
 		  <failure type=\!"failure\!">
 			Expected: add_nums(3, 5) equal to 7
 			But: was 8
 		  </failure>
 		</testcase>
-		<testcase name=\!"Test3\!">
+		<testcase classname=\!"Example Tests 2\!" file=\!"JunitXMLReporterTest\.jsl\!" name=\!"Test3\!">
 		</testcase>
-		<testcase name=\!"Test4\!">
+		<testcase classname=\!"Example Tests 2\!" file=\!"JunitXMLReporterTest\.jsl\!" name=\!"Test4\!">
 		  <failure type=\!"failure\!">
 			Expected: add_nums(3, 5) equal to 9
 			But: was 8
@@ -397,17 +403,36 @@ ut test(JunitXMLReporters, "Multiple successes and failure report as expected", 
 	ut assert that(Expr(match[1]), ut equal to(report));
 ));
 
-// 13.0 Unexpected throws are treated as failures
+// 13.0 Unexpected throws are treated as errors
 
-ut test(JunitXMLReporters, "Unexpected throws are treated as failures", Expr(
-	// There may be some room for improvement here. I think there may be a
-	// separate mechanism for reporting these.
+ut test(JunitXMLReporters, "Unexpected throws are treated as errors", Expr(
 	with junit reporter(Expr(
 		ut test("A", "a", Expr(
 			Throw("I am unexpected!");
 		));
 	));
+
 	ut assert that( Expr(report), ut valid xml() );
 	ut assert that( Expr(n root tests(report)), 1 );
-	ut assert that( Expr(n root failures(report)), 1 );
+	ut assert that( Expr(n root errors(report)), 1 );
+
+	pattern = "<\?xml version=\!"1.0\!" encoding=\!"UTF-8\!" \?>
+	<testsuites errors=\!"1\!" failures=\!"0\!" id=\!"\d+_\d+\!" tests=\!"1\!">
+	  <testsuite errors=\!"1\!" failures=\!"0\!" name=\!"A\!" tests=\!"1\!">
+		<testcase classname=\!"A\!" file=\!"JunitXMLReporterTest\.jsl\!" name=\!"a\!">
+		  <error type=\!"error\!">
+			Expected: Throw\(\!"I am unexpected!\!"\) test does not throw outside of an assertion
+			But: unexpectedly threw \!"I am unexpected!\!"
+		  </error>
+		</testcase>
+	  </testsuite>
+	</testsuites>
+	";
+
+	//replace tabs and carriage returns used for easier readability
+	Substitute Into(pattern, "\!N", ".+", "\!r", ".+", "\!t", "");
+	match = Regex Match(report, pattern);
+	
+	ut assert that(Expr(match), ut length(1));
+	ut assert that(Expr(match[1]), ut equal to(report));
 ));

--- a/Tests/UnitTests/Reporters/JunitXMLReporterTest.jsl
+++ b/Tests/UnitTests/Reporters/JunitXMLReporterTest.jsl
@@ -148,7 +148,7 @@ ut test( JunitXMLReporters, "JunitXMLReporter one simple passing", Expr(
 	     ut assert that(Expr(1+1), ut equal to (2));
 	   ));
 	));
-	ut assert that(Expr(reporter << successes), ut equal to ({{"Simple Pass ⮚ One plus one equals two ⮚ 1", 1 + 1, "equal to 2", Empty()}}));
+	ut assert that(Expr(reporter << n successes), ut equal to (1));
 	pattern = 
 	"\[<\?xml version="1.0" encoding="UTF-8" \?>
 	<testsuites failures="0" id="\d+_\d+" tests="1">
@@ -179,7 +179,7 @@ ut test( JunitXMLReporters, "JunitXMLReporter one simple failing", Expr(
 	    ));
 	));
 	
-	ut assert that(Expr(reporter << failures), ut equal to ({{"Simple Fail ⮚ One plus one equals one ⮚ 1", 1 + 1, "equal to 1", "was 2", 0, Empty()}}));
+	ut assert that(Expr(reporter << n failures), ut equal to (1));
 	
 	pattern = 
 	"\[<\?xml version="1.0" encoding="UTF-8" \?>

--- a/Tests/UnitTests/Reporters/JunitXMLReporterTest.jsl
+++ b/Tests/UnitTests/Reporters/JunitXMLReporterTest.jsl
@@ -15,6 +15,8 @@
 // 11.0 Assertion with 4 part label works
 // 12.0 Multiple successes and failure report as expected
 // 13.0 Unexpected throws are treated as failures
+// 14.0 get file path relative to base dir
+// 14.1 JunitXMLReporter throws with bad base dir
 
 // uncomment to reinitialize and reinclude source file
 //init_framework = convert file path("$ADDIN_HOME(com.jmp.jslhamcrest)\Source\Addin\Actions\InitializeFramework.jsl");
@@ -58,7 +60,9 @@ setup_expr = Expr(
 	
 JunitXMLReporters = ut test case("JunitXMLReporters")
 	<< Setup(Expr(setup_expr));
-	
+
+JunitXMLReportersBaseDir = ut test case("JunitXMLReportersBaseDir");
+
 // 1.0 Factory return correct type
 
 ut test(JunitXMLReporters, "Factory return correct type", Expr(
@@ -435,4 +439,21 @@ ut test(JunitXMLReporters, "Unexpected throws are treated as errors", Expr(
 	
 	ut assert that(Expr(match), ut length(1));
 	ut assert that(Expr(match[1]), ut equal to(report));
+));
+
+// 14.0 get file path relative to base dir
+
+ut test(JunitXMLReportersBaseDir, "get file path relative to base dir", Expr(
+	reporter = ut junit xml reporter("Tests");
+	ut assert that(Expr(reporter << get file path),
+		"Tests/UnitTests/Reporters/JunitXMLReporterTest.jsl"
+	);
+));
+
+// 14.1 JunitXMLReporter throws with bad base dir
+
+ut test(JunitXMLReportersBaseDir, "reporter throws with bad base dir", Expr(
+	ut assert that(Expr(ut junit xml reporter("Tests/UnitTests")),
+		ut throws("UtJunitXMLReporter requires base dir to be a single directory's name.")
+	);
 ));


### PR DESCRIPTION
## Description
I've made various improvements to the JunitXMLReporter with the goal of improving what Gitlab presents from the JUnit.xml.   

* Removed the CollectingReporter as the JUnit reporter's parent
  * This wasn't necessary but I saw no good reason for it to subclass the collecting reporter
* Added a `classname` attribute to testcase tags with the suite name as the value.
* Added a `file` attribute to testcase tags.
  * Gitlab links to the file if the relative path is provided so I made an optional argument `base dir` that should be the top most directory containing all tests 
* Unexpected throws are now reported as errors rather than failures

The end result looks something like this:

![image](https://user-images.githubusercontent.com/6343165/114444320-ba6f6c80-9b9c-11eb-91a4-c057e3dd1966.png)

Duration would be nice to include too but it can wait for another PR.

### Reference
https://llg.cubic.org/docs/junit/

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- Feel free to remove whole sections, not points within the sections, that do not apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] **I am adding new or changing current functionality.**
  - [x] I have added or updated the tests for the new or changed functionality in `Tests/UnitTests`.
  - [x] I have added note(s) to `CHANGELOG.md` as necessary.

## Contributing

- [x] I have read and agree to the [Contributor Agreement](https://github.com/sassoftware/jsl-hamcrest/blob/master/ContributorAgreement.txt)

<!--- Replace your name and e-mail below -->
Signed-off-by: Ben Peachey Higdon <bpeacheyhigdon@gmail.com>
