### PR TITLE
Added ut mock function.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - `ut localized` to enable localizing content using an associative array and language codes.
+- `ut mock function`, `ut expect call`, and `ut verify mock` for testing callbacks
 
 ### Changed
 

--- a/Source/Core/Core.jsl
+++ b/Source/Core/Core.jsl
@@ -15,6 +15,7 @@ ut include jsl files recursively( "Reporters" );
 
 // Requires UtReporter (Reporters/Reporter) and ut ensure matcher (Utils)
 Include( "TestCase.jsl" );
+Include( "Mock.jsl" );
 
 // Section: Globals
 

--- a/Source/Core/Mock.jsl
+++ b/Source/Core/Mock.jsl
@@ -63,41 +63,36 @@ Define Class("UtMockFunction",
 		));
 		---------
 */
-ut mock function = Expr(Function({fnarg1, fnarg2, fnarg3="NOT PROVIDED"}, {obj, body},
-	// Juggle the args into a standardized form
-	// Now fnarg1 is always args, fnarg2 is always local block, fnarg3 is always expression body
-	If(Name Expr(fnarg3) == "NOT PROVIDED",
-		fnarg3 = Name Expr(fnarg2);
-		fnarg2 = {}
-	);
-	
-	// Store the original function
-	obj = New Object("UtMockFunction");
-	obj:orig fn = Eval Expr(Function(
-		Expr(fnarg1),
-		Expr(fnarg2),
-		Expr(Name Expr(fnarg3))
-	));
-	// Now instrument it
-	// Avoid nested Glue (just doesn't read nicely in output)
-	body = Name Expr(fnarg3);
-	body = If(Head(Name Expr(body)) == Expr(Glue()), Name Expr(body), Insert(Expr(Glue()), Name Expr(body)));
-	Insert Into(body, Eval Expr(
-		// Notice we are putting the parameter names in here, when ut verify mock call is actually called
-		// we will be inside the function call and these will resolve to locals with the actual argument values.
-		ut verify mock call(Expr(obj), Expr(fnarg1)); // Prepend args onto given function body
-	), 1); // First thing as soon as the function is called
-	// Reconstruct an instrumented version of the function
-	obj:fn = Eval Expr(Function(
-		Expr(fnarg1),
-		Expr(fnarg2),
-		Expr(Name Expr(body))
-	));
-	obj;
-));
 ut define documented function(
 	"ut mock function",
-	Name Expr(ut mock function),
+	Expr(Function({fnarg1, fnarg2, fnarg3="NOT PROVIDED"}, {obj, body},
+		// Juggle the args into a standardized form
+		// Now fnarg1 is always args, fnarg2 is always local block, fnarg3 is always expression body
+		If(Name Expr(fnarg3) == "NOT PROVIDED",
+			fnarg3 = Name Expr(fnarg2);
+			fnarg2 = {}
+		);
+		
+		// Store the original function
+		obj = New Object("UtMockFunction");
+		obj:orig fn = Eval Expr(Function(
+			Expr(fnarg1),
+			Expr(fnarg2),
+			Expr(Name Expr(fnarg3))
+		));
+		// Now instrument it avoiding nested Glue().
+		// Notice we are putting the parameter names in here, when ut verify mock call is actually called
+		// we will be inside the function call and these will resolve to locals with the actual argument values.
+		If(!Is Expr(Name Expr(fnarg3)), fnarg3 = ut as expr(fnarg3));
+		body = ut merge expressions(EvalExpr({ut verify mock call(Expr(obj), Expr(fnarg1)), Expr(Name Expr(fnarg3))}));
+		// Reconstruct an instrumented version of the function
+		obj:fn = Eval Expr(Function(
+			Expr(fnarg1),
+			Expr(fnarg2),
+			Expr(Name Expr(body))
+		));
+		obj;
+	)),
 	"ut mock function( {args}, <{locals}>, Expr(body) )",
 	"Creates a mock wrapping the given function pieces. Use with ut expect call and ut verify mock to test that the function is called some number of times with matching arguments.",
 	{{"Simple", mock = ut mock function({x}, Expr(.)); ut expect call(mock, {ut greater than(6)}); mock:fn(5); ut verify mock(mock);}}

--- a/Source/Core/Mock.jsl
+++ b/Source/Core/Mock.jsl
@@ -1,0 +1,225 @@
+﻿// Copyright © 2020, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+Names Default To Here( 0 );
+
+// Section: Globals
+
+// This is a partially complete class used to hold a mock function. This includes its original function, its
+// instrumented function, its expectations, and its current expectation. Part of the class is here and the rest is
+// added dynamically by ut mock function. A class is used rather than a namespace so it cleans up after itself.
+Define Class("UtMockFunction",
+	n calls = 0;
+	expectations = {};
+);
+
+/* 
+	Function: ut mock function
+		---Prototype---
+		ut mock function( {args}, <{locals}>, Expr(body) )
+		---------------
+		Used to test expectations on callbacks and the like.
+
+		Creates a mock function that creates a function from the pieces provided and decorates it.
+		Returns an object (called obj in this document) with the decorated function accessible via obj:fn.
+		You can then use ut expect call(obj, ...) with a list of matchers to set expectations. You should call
+		this once for each time you expect your function to be called. This should be done before the calls to
+		your function. As your function is called, these expectations are checked one by one. Then, after you
+		test body is over, call ut verify mock(obj). This will make sure you got the correct number of calls.
+
+		Note, it is /extremely/ important that you ensure that ut verify mock is called. Otherwise, your test
+		will *silently pass* even if you didn't get all the calls you expected. The easiest way to ensure this
+		is to call it in the Teardown of a ut test case.
+
+		Users of other mock frameworks may notice that this is a little more than a mock since we are
+		instrumenting an arbitrary function. However, this was the easiest way to supply both the signature and
+		return to the ut mock function factory. And it gives us some extra flexibility. So hopefully you'll
+		forgive me stretching the definition. Also, it doesn't have the capability (yet) to change the body
+		of the function for each expectation. However, this is something I hope to add.
+
+		Another difference from other mock frameworks is that this verifies the expectations eagerly in the
+		instrumented function. This is useful when the arguments may not live past the callback call and they
+		can not be cloned. One common example of this is Display Boxes.
+
+		Use obj:fn(...) to call the instrumented function. And use obj:orig fn(...) to call the uninstrumented
+		function.
+		
+		When calling ut mock function, you can omit the locals list if desired.
+
+	Arguments:
+		args - args list
+		locals - locals list
+		body - an expression using args and locals 
+
+	Example:
+		---JSL---
+		Button Box Test = ut test case("Button Box")
+		    << Setup(Expr(mock = ut mock function({this}, Expr(.))))
+		    << Teardown(Expr(ut verify mock(mock)));
+		ut test(Button Box Test, "Calls Callback", Expr(
+		    ut expect call(mock, {ut enabled(1)});
+		    New Window("", btn = Button Box("Hi", << Set Function(Function({this}, mock:fn(this)))));
+		    btn << Click;
+		));
+		---------
+*/
+ut mock function = Expr(Function({fnarg1, fnarg2, fnarg3="NOT PROVIDED"}, {obj, body},
+	// Juggle the args into a standardized form
+	// Now fnarg1 is always args, fnarg2 is always local block, fnarg3 is always expression body
+	If(Name Expr(fnarg3) == "NOT PROVIDED",
+		fnarg3 = Name Expr(fnarg2);
+		fnarg2 = {}
+	);
+	
+	// Store the original function
+	obj = New Object("UtMockFunction");
+	obj:orig fn = Eval Expr(Function(
+		Expr(fnarg1),
+		Expr(fnarg2),
+		Expr(Name Expr(fnarg3))
+	));
+	// Now instrument it
+	// Avoid nested Glue (just doesn't read nicely in output)
+	body = Name Expr(fnarg3);
+	body = If(Head(Name Expr(body)) == Expr(Glue()), Name Expr(body), Insert(Expr(Glue()), Name Expr(body)));
+	Insert Into(body, Eval Expr(
+		// Notice we are putting the parameter names in here, when ut verify mock call is actually called
+		// we will be inside the function call and these will resolve to locals with the actual argument values.
+		ut verify mock call(Expr(obj), Expr(fnarg1)); // Prepend args onto given function body
+	), 1); // First thing as soon as the function is called
+	// Reconstruct an instrumented version of the function
+	obj:fn = Eval Expr(Function(
+		Expr(fnarg1),
+		Expr(fnarg2),
+		Expr(Name Expr(body))
+	));
+	obj;
+));
+ut define documented function(
+	"ut mock function",
+	Name Expr(ut mock function),
+	"ut mock function( {args}, <{locals}>, Expr(body) )",
+	"Creates a mock wrapping the given function pieces. Use with ut expect call and ut verify mock to test that the function is called some number of times with matching arguments.",
+	{{"Simple", mock = ut mock function({x}, Expr(.)); ut expect call(mock, {ut greater than(6)}); mock:fn(5); ut verify mock(mock);}}
+);
+
+// Called by ut verify mock to ensure that the mock has been called AT LEAST as many times as it has expectations.
+// If called more times, we don't issue a failure. This is because a failure has already been eagerly issued at the
+// time of the offending call and we don't want to spam the user with redundant failure information. This matcher
+// MUST be run the enforce that the mock recieved the correct number of calls.
+Define Class("UtMockFunctionEnoughCallsMatcher",
+	Base Class("UtMatcher"),
+	mock = Empty();
+	_init_ = Method({mock},
+		this:mock = mock;
+	);
+	matches = Method({_},
+		If(mock:n calls < N Items(mock:expectations),
+			ut match info failure( Eval Insert( "called ^Char(mock:n calls)^ times" ) ),
+			ut match info success()
+		)
+	);
+	describe = Method({},
+		Eval Insert("called ^Char(N Items(mock:expectations))^ times");
+	);
+);
+
+// Called eagerly during each mock function invocation. Match the args for this invocation with the current
+// expectation. If they fail to match, manipulate the failure info to add a little more context about the
+// mock call number. Issue a distinct failure if there aren't enough expectations. Description also changes
+// in this case.
+Define Class("UtMockFunctionCalledWithArgsMatcher",
+	Base Class("UtMatcher"),
+	mock = Empty();
+	args = {};
+	_init_ = Method({mock, args},
+		this:mock = mock;
+		this:args = args;
+	);
+	matches = Method({_},
+		If(mock:n calls <= N Items(mock:expectations),
+			out = ut expression matches(mock:expectations[mock:n calls]) << matches(args);
+			If(!(out << is success),
+				out:mismatch = Eval Insert("during call ^Char(mock:n calls)^, arg ^out:mismatch^");
+			);
+			out
+		,
+			ut match info failure( Eval Insert( "called ^Char(mock:n calls)^ times, most recently with ^Char(args)^" ) )
+		)
+	);
+	describe = Method({},
+		If(mock:n calls <= N Items(mock:expectations),
+			ut expression matches(mock:expectations[mock:n calls]) << describe,
+			Eval Insert("called ^Char(N Items(mock:expectations))^ times")
+		)
+	);
+);
+
+// Injected into the mock function to keep track of the current expectation and to eagerly test the
+// args against the current expectation. Note that this uses dynamic scoping to look at the args as
+// they are just the arg names at this point. See UtMockFunctionCalledWithArgsMatcher _init_.
+ut verify mock call = Function({mock, args}, {},
+	mock:n calls++;
+	// Eval List(args) uses dynamic scoping
+	ut assert value(Name Expr(mock:orig fn), New Object("UtMockFunctionCalledWithArgsMatcher"(mock, Eval List(args))))
+);
+
+/* 
+	Function: ut expect call
+		---Prototype---
+		ut expect call( mock, {arg1 matcher, arg2 matcher, ...} )
+		---------------
+		Use with ut mock function to define expectations for mocked functions.
+
+		Must be given a list of values or matchers. These represent a single call to the mock function.
+		They are appended to a list of expectations and matched when the mock function has been called
+		the appropriate number of times. If the number of matchers doesn't match or any matcher fails,
+		the call expectation fails.
+
+		This is a function to avoid class member lookup rules and enable syntax highlighting and
+		Scripting Index help.
+    
+	Arguments:
+		mock - any mock
+		call - list of matchers
+*/
+ut expect call = Expr(Function({mock, arg matchers},
+	Insert Into(mock:expectations, Eval List({Name Expr(arg matchers)}))
+));
+ut define documented function(
+	"ut expect call",
+	Name Expr(ut expect call),
+	"ut expect call( mock, {arg1 matcher, arg2 matcher, ...} )",
+	"Defines expectations for a mock function. Must be called before the actual call to the mock.",
+	{{"Simple", mock = ut mock function(Function({x}, .)); ut expect call(mock, {ut greater than(6)}); mock:fn(5)}}
+);
+
+
+/* 
+	Function: ut verify mock
+		---Prototype---
+		ut verify mock( mock )
+		---------------
+		Use with ut mock function to test that a mock function has been called the expected number of times.
+
+		If this function is not called, you will only be testing that the calls (actually done) to the mock
+		match the expectations and that there were at least as many expectations as calls. But you won't
+		catch the case where the mock isn't called enough times. For instance, you wouldn't catch the common
+		failure case of NO calls to the mock even though you had expected some. Be sure to call this function
+		for all your mocks.
+
+		This is a function rather than a message so we get syntax highlighting and Scripting Index help.
+
+	Arguments:
+		mock - any mock
+*/
+ut verify mock = Expr(Function({mock}, {},
+	ut assert value(Name Expr(mock:orig fn), New Object("UtMockFunctionEnoughCallsMatcher"(mock)))
+));
+ut define documented function(
+	"ut verify mock",
+	Name Expr(ut verify mock),
+	"ut verify mock( mock )",
+	"Tests that a mock function has been called the expected number of times. Should be called after other testing is complete.",
+	{{"Simple", mock = ut mock function({}, Expr(.)); mock:fn(5); ut verify mock(mock)}}
+);

--- a/Tests/UnitTests/MockTest.jsl
+++ b/Tests/UnitTests/MockTest.jsl
@@ -26,6 +26,11 @@ ut test("Mock Function", "Passthrough No Arguments", Expr(
 	ut assert that(Expr(with noop reporter(Expr(mock:fn))), 33);
 ));
 
+ut test("Mock Function", "Body can have glue", Expr(
+	mock = ut mock function({}, Expr(local:x = 33; local:x));
+	ut assert that(Expr(with noop reporter(Expr(mock:fn))), 33);
+));
+
 ut test("Mock Function", "List allowed as body", Expr(
 	mock = ut mock function({x}, Expr({1}));
 	ut assert that(Expr(with noop reporter(Expr(mock:fn(5)))), {1});

--- a/Tests/UnitTests/MockTest.jsl
+++ b/Tests/UnitTests/MockTest.jsl
@@ -1,0 +1,167 @@
+﻿// Copyright © 2020, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+ut test("Mock Function", "Passthrough Return", Expr(
+	mock = ut mock function({x}, Expr(x*10));
+	ut assert that(Expr(with noop reporter(Expr(mock:fn(5)))), 50);
+));
+
+ut test("Mock Function", "Allows Throw", Expr(
+	mock = ut mock function({x}, Expr(Throw(Char(x))));
+	ut assert that(Expr(with noop reporter(Expr(mock:fn(5)))), ut throws("5"));
+));
+
+ut test("Mock Function", "Passthrough Multiple Arguments", Expr(
+	mock = ut mock function({x, y}, Expr(x + y*10));
+	ut assert that(Expr(with noop reporter(Expr(mock:fn(5, 6)))), 65);
+));
+
+ut test("Mock Function", "Arguments Not Evaluated", Expr(
+	mock = ut mock function({e}, Expr(Name Expr(e)));
+	ut assert that(Expr(with noop reporter(Expr(mock:fn(Expr(1 + 2))))), Expr(1 + 2));
+));
+
+ut test("Mock Function", "Passthrough No Arguments", Expr(
+	mock = ut mock function({}, Expr(33));
+	ut assert that(Expr(with noop reporter(Expr(mock:fn))), 33);
+));
+
+ut test("Mock Function", "List allowed as body", Expr(
+	mock = ut mock function({x}, Expr({1}));
+	ut assert that(Expr(with noop reporter(Expr(mock:fn(5)))), {1});
+));
+
+ut test("Mock Function", "First argument isn't validated until call", Expr(
+	mock = ut mock function(., Expr(1 + 1));
+	ut assert that(Expr(mock:fn), ut throws("argument should be list"));
+));
+
+ut test("Mock Function", "Local block works", Expr(
+	Delete Symbols(b);
+	mock = ut mock function({a}, {b=10}, Expr(b=100; a + b));
+	ut assert that(Expr(with noop reporter(Expr(mock:fn(5)))), 105);
+	ut assert that(Expr(Namespace("global") << Get Keys), ut not(ut contains("b")))
+));
+
+with reporter = Function( {ex},
+    ut with reporter( reporter, Name Expr( ex ) );
+);
+
+// Note that we are using ut mock reporter to test ut mock function. They
+// are two different things that share a common idea. Hopefully, their
+// similarity doesn't make the tests too confusing.
+Mock Function = ut test case("Mock Function")
+	<<Setup(Expr(
+		reporter = ut mock reporter();
+	))
+	<<Teardown(Expr(
+		reporter << verify expectations;
+	));
+
+ut test(Mock Function, "Adds failure with no expect", Expr(
+	mock = ut mock function({x}, Expr(.));
+	reporter << Expect Call(Expr(add failure(ut starts with("Mock Function"), ut wild, "called 0 times", "called 1 times, most recently with {7}", ut wild, ut wild)));
+	with reporter(Expr(mock:fn(7)));
+));
+
+ut test(Mock Function, "Adds success with matching expect", Expr(
+	mock = ut mock function({x}, Expr(.));
+	ut expect call(mock, {ut greater than(4)});
+	reporter << Expect Call(Expr(add success(ut wild, ut wild, ut wild, ut wild)));
+	with reporter(Expr(mock:fn(4 + 1)));
+));
+
+ut test(Mock Function, "Adds failure with non-matching expect", Expr(
+	mock = ut mock function({x}, Expr(.));
+	ut expect call(mock, {ut greater than(4)});
+	reporter << Expect Call(Expr(add failure(ut wild, ut wild, "equal to {ut greater than(4)}", "during call 1, arg /{}[1] was 4 but expected greater than 4 within {4}", ut wild, ut wild)));
+	with reporter(Expr(mock:fn(4 + 0)));
+));
+
+ut test(Mock Function, "Accounts for more than one argument", Expr(
+	mock = ut mock function({x, y}, Expr(.));
+	ut expect call(mock, {ut greater than(4), ut less than(10)});
+	ut expect call(mock, {ut greater than(4), ut less than(10)});
+	ut expect call(mock, {ut greater than(4), ut less than(10)});
+	ut expect call(mock, {ut greater than(4), ut less than(10)});
+	reporter << Expect Call(Expr(add failure(ut wild, ut wild, "equal to {ut greater than(4), ut less than(10)}", "during call 1, arg /{}[2] was 11 but expected less than 10 within {5, 11}", ut wild, ut wild)));
+	reporter << Expect Call(Expr(add failure(ut wild, ut wild, "equal to {ut greater than(4), ut less than(10)}", "during call 2, arg /{}[1] was 3 but expected greater than 4 within {3, 9}", ut wild, ut wild)));
+	reporter << Expect Call(Expr(add failure(ut wild, ut wild, "equal to {ut greater than(4), ut less than(10)}", "during call 3, arg /{}[1] was 3 but expected greater than 4 within {3, 11}", ut wild, ut wild)));
+	reporter << Expect Call(Expr(add success(ut wild, ut wild, ut wild, ut wild)));
+	with reporter(Expr(
+		mock:fn(5, 11);
+		mock:fn(3, 9);
+		mock:fn(3, 11);
+		mock:fn(5, 9);
+	));
+));
+
+ut test(Mock Function, "Expectations can change for each call", Expr(
+	mock = ut mock function({x, y}, Expr(.));
+	ut expect call(mock, {0, 1});
+	ut expect call(mock, {2, 3});
+	reporter << Expect Call(Expr(add success(ut wild, ut wild, ut wild, ut wild)));
+	reporter << Expect Call(Expr(add success(ut wild, ut wild, ut wild, ut wild)));
+	with reporter(Expr(
+		mock:fn(0, 1);
+		mock:fn(2, 3);
+	));
+));
+
+ut test(Mock Function, "Adds failure with fewer expects", Expr(
+	mock = ut mock function({x}, Expr(.));
+	ut expect call(mock, {7});
+	reporter << Expect Call(Expr(add success(ut wild, ut wild, ut wild, ut wild)));
+	reporter << Expect Call(Expr(add failure(ut wild, ut wild, "called 1 times", "called 2 times, most recently with {8}", ut wild, ut wild)));
+	with reporter(Expr(
+		mock:fn(7);
+		mock:fn(8);
+	));
+));
+
+ut test(Mock Function, "Can expect no arguments", Expr(
+	mock = ut mock function({}, Expr(.));
+	ut expect call(mock, {});
+	reporter << Expect Call(Expr(add success(ut wild, ut wild, ut wild, ut wild)));
+	with reporter(Expr(mock:fn));
+));
+
+ut test(Mock Function, "Verify mock add success on more calls than expects", Expr(
+	// So we don't issue too many redundant failures
+	mock = ut mock function({}, Expr(.));
+	with noop reporter(Expr(mock:fn));
+	reporter << Expect Call(Expr(add success(ut wild, ut wild, ut wild, ut wild)));
+	with reporter(Expr(ut verify mock(mock)));
+));
+
+ut test(Mock Function, "Verify mock add success matching calls and expects", Expr(
+	// So we don't issue too many redundant failures
+	mock = ut mock function({}, Expr(.));
+	ut expect call(mock, {});
+	with noop reporter(Expr(mock:fn));
+	reporter << Expect Call(Expr(add success(ut wild, ut wild, ut wild, ut wild)));
+	with reporter(Expr(ut verify mock(mock)));
+));
+
+ut test(Mock Function, "Verify mock add failure on more expects than calls", Expr(
+	// So we don't issue too many redundant failures
+	mock = ut mock function({}, Expr(.));
+	ut expect call(mock, {});
+	ut expect call(mock, {});
+	with noop reporter(Expr(mock:fn));
+	reporter << Expect Call(Expr(add failure(ut wild, ut wild, "called 2 times", "called 1 times", ut wild, ut wild)));
+	with reporter(Expr(ut verify mock(mock)));
+));
+
+ut test(Mock Function, "Assumes ut equal to", Expr(
+	mock = ut mock function({x}, Expr(.));
+	ut expect call(mock, {5});
+	reporter << Expect Call(Expr(add success(ut wild, ut wild, ut wild, ut wild)));
+	with reporter(Expr(mock:fn(5)));
+));
+
+ut test(Mock Function, "Orig Fn is not instrumented", Expr(
+	mock = ut mock function({x}, Expr(.));
+	ut expect call(mock, {ut greater than(4)});
+	with reporter(Expr(mock:orig fn(4 + 1)));
+));


### PR DESCRIPTION
## Description
This adds `ut mock function`, `ut expect call`, and `ut verify mock` that are useful when testing callbacks.

```
Button Box Test = ut test case("Button Box")
    <<Setup(Expr(
        mock = ut mock function({this}, Expr(1+1))
    ))
    <<Teardown(Expr(
        ut verify mock(mock)
    ));
	
ut test(Button Box Test, "Calls Callback", Expr(
    ut expect call(mock, {ut enabled(1)});
    New Window("", btn = Button Box("Hi", << Set Function(Function({this}, mock:fn(this)))));
    btn << Click;
));
```

## Checklist

- [x] **I am adding new or changing current functionality.**
  - [x] I have added or updated the tests for the new or changed functionality in `Tests/UnitTests`.
  - [x] I have added note(s) to `CHANGELOG.md` as necessary.

## Contributing

- [x] I have read and agree to the [Contributor Agreement](https://github.com/sassoftware/jsl-hamcrest/blob/master/ContributorAgreement.txt)

<!--- Replace your name and e-mail below -->
Signed-off-by: Evan McCorkle <Evan.McCorkle@jmp.com>
