### PR TITLE
The box reference isn't always a reliable key.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Avoid potential collision with builtin functions in `UtSizeMatcher` (#109, #111)
-- `UtWindowDispatchingReporter` now uses a more reliable key which works for any box within a window
+- `UtWindowDispatchingReporter` now uses a more reliable key which works for any box within a window (#118)
 
 ## [1.2.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Avoid potential collision with builtin functions in `UtSizeMatcher` (#109, #111)
+- `UtWindowDispatchingReporter` now uses a more reliable key which works for any box within a window
 
 ## [1.2.0]
 

--- a/Source/Addin/Reporters.jsl
+++ b/Source/Addin/Reporters.jsl
@@ -109,13 +109,13 @@ Define Class("UtWindowDispatchingReporter",
 		this:by window << Set Default Value(default reporter);
 		this:reporters = Eval List({by window << Get Default Value});
 	);
-	register reporter = Method({win, reporter}, this:by window[win] = reporter );
+	register reporter = Method({win, reporter}, this:by window[win << Get Window ID] = reporter );
 	unregister reporter = Method({win},
-		this:by window << Remove Item( win );
+		this:by window << Remove Item( win << Get Window ID );
 	);
-	get reporter = Method({win}, this:by window[win] );
+	get reporter = Method({win}, this:by window[win << Get Window ID] );
 	on run start = Method( {},
-		this:reporters = Eval List({by window[Current Window()]});
+		this:reporters = Eval List({by window[Current Window() << Get Window ID]});
 		this:reporters << on run start()
 	);
 	on run end = Method( {},


### PR DESCRIPTION
`UtWindowDispatchingReporter` now uses a more reliable key which works for any box within a window

## Contributing

- [X] I have read and agree to the [Contributor Agreement](https://github.com/sassoftware/jsl-hamcrest/blob/master/ContributorAgreement.txt)

<!--- Replace your name and e-mail below -->
Signed-off-by: Evan McCorkle <Evan.McCorkle@jmp.com>
