### PR TITLE
Decorated assertions don't report as anonymous.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file.
 - Avoid potential collision with builtin functions in `UtSizeMatcher` (#109, #111)
 - `UtWindowDispatchingReporter` now uses a more reliable key which works for any box within a window (#118)
 - Added `ut parsed` to the Scripting Index (#115)
+- `ut test` decorated assertions no longer report as anonymous functions (#119)
 
 ## [1.2.0]
 

--- a/Source/Core/TestCase.jsl
+++ b/Source/Core/TestCase.jsl
@@ -751,9 +751,9 @@ ut test assertion decorator = Function( {function name, args},
 		);
 	);
 	Parse( Eval Insert( "
-		local:^function name^ = Function( ^Char(args)^,
+		local:^function name^ = Function( ^args^,
 			_utTestNS:n asserts++;
-			Insert Into( _utTestNS:results, ^Char(Name Expr(inner call))^ );
+			Insert Into( _utTestNS:results, ^Name Expr(inner call)^ );
 			_utTestNS:results[N Items( _utTestNS:results )];
 		)";
 	) );

--- a/Source/Core/TestCase.jsl
+++ b/Source/Core/TestCase.jsl
@@ -750,15 +750,13 @@ ut test assertion decorator = Function( {function name, args},
 			Insert Into( inner call, Eval Expr( Name Expr( Expr( Name Expr( arg ) ) ) ) )
 		);
 	);
-	Eval Expr(
-		As Scoped( local, Expr( function name ) ) = Function( Expr( args ),
+	Parse( Eval Insert( "
+		local:^function name^ = Function( ^Char(args)^,
 			_utTestNS:n asserts++;
-			Insert Into( _utTestNS:results, 
-				Expr( Name Expr( inner call ) );
-			);
+			Insert Into( _utTestNS:results, ^Char(Name Expr(inner call))^ );
 			_utTestNS:results[N Items( _utTestNS:results )];
-		)
-	)
+		)";
+	) );
 );
 
 /*	Function: ut expand test

--- a/Tests/UnitTests/TestCaseTest.jsl
+++ b/Tests/UnitTests/TestCaseTest.jsl
@@ -64,3 +64,9 @@ assert rc = with noop reporter( Expr(
 ));
 ut assert that( Expr( assert rc ), 1, "Row unset within test" );
 ut assert that( Expr( Row() ), 201, "Row restored to set" );
+
+Local({},
+	Eval(ut test assertion decorator("ut assert that", {test expr, matcher, label=""}));
+	Try(exception_msg = ""; local:ut assert that());
+	::ut assert that(Expr(exception_msg[1]), ut starts with("local:ut assert that has 3 parameters"));
+);


### PR DESCRIPTION
Closes #119

## Checklist

- [X] **I am adding new or changing current functionality.**
  - [X] I have added or updated the tests for the new or changed functionality in `Tests/UnitTests`.
  - [X] I have added note(s) to `CHANGELOG.md` as necessary.

## Contributing

- [X] I have read and agree to the [Contributor Agreement](https://github.com/sassoftware/jsl-hamcrest/blob/master/ContributorAgreement.txt)

<!--- Replace your name and e-mail below -->
Signed-off-by: Evan McCorkle <Evan.McCorkle@jmp.com>
