### PR TITLE
Explicitly use a four-part label.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ All notable changes to this project will be documented in this file.
 - Convenience `ut throws` helper functions now use `ut localize` to assert using the current languages error message.
 - `UtJunitXMLReporter` reports file and classname attributes for testcases and treats throws differently from failures.
 - The `ut skip` matcher now issues a `skip` rather than a `success`. The `ut skip succeeding` matcher has the old behavior.
+- The `label` is now explicitly given to the reporter a four-element list rather than having to split on `ut concat test label sep`.
+  These are `{case name, test name, assertion label, assertion id}`. The `ut concat test label` function has been removed and
+  replaced by a combination of `ut form test label`, `ut format test label`, and `ut fwd test label`. A quick rewrite of the `label`
+  argument in your `UtReporter` messages like `label = ut format test label(label)` will get back to the old behavior. (#59)
 
 ### Fixed
 

--- a/Source/Addin/Reporters.jsl
+++ b/Source/Addin/Reporters.jsl
@@ -229,7 +229,7 @@ Define Class("UtDetailsTreeReporter",
 		this:on run start();
 	);
 	update node = Method({node, event type, label, payload},
-		Insert Into(payload, label, 1);
+		Insert Into(payload, ut format test label(label), 1);
 		Insert Into(payload, event type, 1);
 		node << Set Data(Insert(node << Get Data, Eval List({payload})));
 		update node icon(node);	
@@ -248,7 +248,12 @@ Define Class("UtDetailsTreeReporter",
 		                      -1, ut icon("skip-32px")));
 		If(final type == 0,	this:box << Collapse(node),	this:box << Expand(node));
 	);
-	process test case event = Method({event type, full label, case label, test label, assertion label, assertion id, payload},
+	process test case event = Method({event type, label, payload},
+		case label = label[1];
+		test label = label[2];
+		assertion label = label[3];
+		assertion id = label[4];
+
 		local cases = this:cases;
 		tests = ut get or create(Expr(local cases), case label, Eval(Eval Expr(Function({case label}, {case, tests},
 			case = ut make new node(case label);
@@ -265,26 +270,20 @@ Define Class("UtDetailsTreeReporter",
 		));
 		local cases[case label] = tests;
 		this:cases = local cases;
-		this:update node(test, event type, full label, payload);
-		this:update node(case, event type, full label, payload);
+		this:update node(test, event type, label, payload);
+		this:update node(case, event type, label, payload);
 	);
 	process free event = Method({event type, label, payload},
 		case = this:cases << Get Default Value();
-		test = ut make new node(If(Length(label), label, "[Unlabeled]"));
+		test = ut make new node(If(Length(label[3]), label[3], "[Unlabeled]"));
 		case << Append(test);
 		this:update node(test, event type, label, payload);
 		this:update node(case, event type, label, payload);
 	);
 	process event = Method({event type, label, payload},
-		details = If(Length(label), Words(label, ::ut concat test label sep), {""});
-		If(
-			Length(details) == 1, // Label (optional)
-				this:process free event(event type, label, payload),
-			Length(details) == 3, // Test Case, Test, Assertion Id
-				this:process test case event(event type, label, details[1], details[2], "", details[3], payload),
-			Length(details) == 4, // Test Case, Test, Label, Assertion Id
-				this:process test case event(event type, label, details[1], details[2], details[3], details[4], payload),
-			Throw(Eval Insert("Ill-formed label: ^label^"))
+		If(Length(label[1]),
+			this:process test case event(event type, label, payload),
+			this:process free event(event type, label, payload)
 		)
 	);
 	add expression failure = Method( {label, payload=Empty()},

--- a/Source/Core/Core.jsl
+++ b/Source/Core/Core.jsl
@@ -53,7 +53,7 @@ ut define documented function(
 	Expr(Function( {test expr, matcher, label = ""},
 		// Move args to anonymous namespace to avoid collision
 		local:_utAssertThatNS = ut move to anonymous namespace( Namespace( "local" ) );
-		
+
 		// Ensure that test expr is an expression
 		// This is done more for safety than for necessity.
 		//
@@ -66,7 +66,7 @@ ut define documented function(
 		// call to ut assert that.
 
 		If( !Is Expr( Name Expr( _utAssertThatNS:test expr ) ),
-			ut global reporter:add expression failure( Name Expr( _utAssertThatNS:label ) );
+			ut global reporter:add expression failure( ut fwd test label( Name Expr( _utAssertThatNS:label ) ) );
 			Return( 0 );
 		);
 		
@@ -92,7 +92,7 @@ ut define documented function(
 			If( !(match info << Is Success()),
 				If( Is Empty( thrown exception ),
 					ut global reporter:add failure(
-						Name Expr( _utAssertThatNS:label ),
+						ut fwd test label( Name Expr( _utAssertThatNS:label ) ),
 						Name Expr( _utAssertThatNS:test expr ),
 						_utAssertThatNS:matcher << Describe(),
 						match info << Get Mismatch(),
@@ -101,7 +101,7 @@ ut define documented function(
 					0;
 				,
 					ut global reporter:add unexpected throw(
-						Name Expr( _utAssertThatNS:label ),
+						ut fwd test label( Name Expr( _utAssertThatNS:label ) ),
 						Name Expr( _utAssertThatNS:test expr ),
 						_utAssertThatNS:matcher << Describe(),
 						thrown exception
@@ -112,7 +112,7 @@ ut define documented function(
 				Try(match info:skip, 0)
 			,
 				ut global reporter:add skip( 
-					Name Expr( _utAssertThatNS:label ), 
+					ut fwd test label( Name Expr( _utAssertThatNS:label ) ),
 					Name Expr( _utAssertThatNS:test expr ),
 					_utAssertThatNS:matcher << Describe(),
 					match info:skip description
@@ -121,7 +121,7 @@ ut define documented function(
 			,
 				// Else
 				ut global reporter:add success( 
-					Name Expr( _utAssertThatNS:label ), 
+					ut fwd test label( Name Expr( _utAssertThatNS:label ) ),
 					Name Expr( _utAssertThatNS:test expr ),
 					_utAssertThatNS:matcher << Describe()
 				);

--- a/Source/Core/Reporters/Reporter.jsl
+++ b/Source/Core/Reporters/Reporter.jsl
@@ -19,7 +19,7 @@ Define Class(
 	// the test fails to even start.
 	//
 	// Parameters:
-	//    label - any extra information about test
+	//    label - {case name, test name, assertion label, assertion id}
 	//    payload - any object which can used to send other information about the test (meaning negotiated between a family of assertions and reporters)
 	//
 	add expression failure = Method( {label, payload=Empty()}, 0 );
@@ -29,7 +29,7 @@ Define Class(
 	// To be used when test expr fails to satisfy the test.
 	//
 	// Parameters:
-	//    label - any extra information about the test
+	//    label - {case name, test name, assertion label, assertion id}
 	//    test expr - object or expression under test
 	//    description - what was being tested
 	//    mismatch - why test expr failed to satisfy the test
@@ -46,7 +46,7 @@ Define Class(
 	// because a throw was unexpectedly encountered.
 	//
 	// Parameters:
-	//    label - any extra information about the test
+	//    label - {case name, test name, assertion label, assertion id}
 	//    test expr - object or expression under test
 	//    description - what was being tested
 	//    exception - the message from the unexpected throw
@@ -61,7 +61,7 @@ Define Class(
 	// To be used when a test fails (not much information currently needed)
 	//
 	// Parameters:
-	//    label - any extra information about test
+	//    label - {case name, test name, assertion label, assertion id}
 	//    test expr - object or expression under test
 	//    description - what was being tested
 	//    payload - any object which can used to send other information about the test
@@ -73,7 +73,7 @@ Define Class(
 	// To be used when a test is skipped (not run) for some reason.
 	//
 	// Parameters:
-	//    label - any extra information about test
+	//    label - {case name, test name, assertion label, assertion id}
 	//    test expr - object or expression under test
 	//    description - what was being tested
 	//    skip description - why was this test skipped?

--- a/Source/Core/TestCase.jsl
+++ b/Source/Core/TestCase.jsl
@@ -373,7 +373,7 @@ Define Class(
 		the label.
 */
 ut test log benchmark label = Function({case name, test name},
-	Eval Insert( "^ut concat test label( case name, test name, \!"Log Benchmark\!" )^" )
+	ut form test label( case name, test name, "Log Benchmark" )
 );
 
 /* 
@@ -477,7 +477,7 @@ ut define documented function(
 			,
 				Names Default to Here( 0 );
 				ut global reporter << Add Unexpected Throw( 
-					ut concat test label(
+					ut form test label(
 						_utTestNS:test case << Get Test Case Name(),
 						_utTestNS:test name,
 						"Setup"
@@ -497,7 +497,7 @@ ut define documented function(
 				Names Default to Here( 0 );
 			,
 				Names Default to Here( 0 );
-				_utTestNS:temp label = ut concat test label(
+				_utTestNS:temp label = ut form test label(
 					_utTestNS:test case << Get Test Case Name(),
 					_utTestNS:test name,
 					"Test"
@@ -519,7 +519,7 @@ ut define documented function(
 			,
 				Names Default to Here( 0 );
 				ut global reporter << Add Unexpected Throw( 
-					ut concat test label(
+					ut form test label(
 						_utTestNS:test case << Get Test Case Name(),
 						_utTestNS:test name,
 						"Teardown"
@@ -540,7 +540,7 @@ ut define documented function(
 		,
 			Names Default to Here( 0 );
 			ut global reporter << Add Unexpected Throw( 
-				ut concat test label(
+				ut form test label(
 					_utTestNS:test case << Get Test Case Name(),
 					_utTestNS:test name,
 					"Skip If"
@@ -554,7 +554,7 @@ ut define documented function(
 			
 		If(!Is Number(Name Expr(_utTestNS:skip?)) | Is Missing(_utTestNS:skip?),
 			ut global reporter << Add Unexpected Throw( 
-				ut concat test label(
+				ut form test label(
 					_utTestNS:test case << Get Test Case Name(),
 					_utTestNS:test name,
 					"Skip If"
@@ -567,7 +567,7 @@ ut define documented function(
 		
 		If( _utTestNS:skip?,
 			ut global reporter << Add Skip( 
-				ut concat test label(
+				ut form test label(
 					_utTestNS:test case << Get Test Case Name(),
 					_utTestNS:test name,
 					"Skip"
@@ -692,9 +692,11 @@ ut test registered assertions = {};
 
 		Allows <ut test> to decorate registered assertions. All 
 		arguments will be passed verbatim except for a label 
-		argument, which will be transformed by <ut test> using
-		<ut concat test label> with the test case name, test 
-		name, and number of assertions.
+		argument, which will be augmented by <ut test> using
+		<ut form test label> with the test case name, test 
+		name, and number of assertions. Your function should
+		use <ut fwd test label> with your given label before
+		sending to the reporter.
 
 		The given args will be the signature of the decorator
 		function. This should match the signature of your
@@ -739,7 +741,7 @@ ut test assertion decorator = Function( {function name, args},
 		If( Name Expr( arg ) == Expr( label ),
 			Insert Into( inner call,
 				Expr(
-					ut concat test label(
+					ut form test label(
 						_utTestNS:test case << Get Test Case Name(), 
 						_utTestNS:test name,
 						Name Expr( label ),

--- a/Source/Core/Utils.jsl
+++ b/Source/Core/Utils.jsl
@@ -556,18 +556,37 @@ ut new object = Function({class name, args={}}, {obj},
 // Variable: ut concat test label sep
 ut concat test label sep = "⮚";
 
-/*	Function: ut concat test label
+/*	Function: ut format test label
 	 		Concatenates values together for <ut test>
 */
-ut concat test label = Function({test case name, test name, label="", n asserts=.},
+ut format test label = Function({label},
 	{labelList},
 	labelList = {};
-	Insert Into( labelList, test case name );
-	Insert Into( labelList, test name );
-	If( label != "",  Insert Into( labelList, label ) );
-	If( !Is Missing( n asserts ), Insert Into( labelList, Char( n asserts ) ) );
-	
+	If( label[1] != "", Insert Into( labelList, label[1] ) );
+	If( label[2] != "", Insert Into( labelList, label[2] ) );
+	If( label[3] != "", Insert Into( labelList, label[3] ) );
+	If( !Is Missing( label[4] ), Insert Into( labelList, Char( label[4] ) ) );
+
 	Concat Items( local:labelList, " " || ut concat test label sep || " " );
+);
+
+/*	Function: ut form test label
+	 		Creates label list for `<UtReporter>`
+*/
+ut form test label = Function({test case name, test name, label="", n asserts=.},
+        Eval List({test case name, test name, label, n asserts})
+);
+
+/*	Function: ut fwd test label
+	 		Creates {"", "", label, .} or forwards label list.
+	 		To be used in registered assertions when sending labels
+	 		to the reporter.
+*/
+ut fwd test label = Function({label},
+	If(Is List(Name Expr(label)),
+		label,
+		Eval List({"", "", Name Expr(label), .})
+	);
 );
 
 /*	Function: ut merge expressions

--- a/Source/Reporters/CollectingReporter.jsl
+++ b/Source/Reporters/CollectingReporter.jsl
@@ -105,7 +105,7 @@ Define Class(
 				Char( Name Expr( this:successes[i][2] ) ),
 				Char( this:successes[i][2] )
 			) || " ";
-			Write( "\!n  Label: " || this:successes[i][1] || "\!n" );
+			Write( "\!n  Label: " || ut format test label(this:successes[i][1]) || "\!n" );
 			Write( "  Expected: " || char test expr || this:successes[i][3] || "\!n" );
 		);
 		Write( "\!n-------------- Failures --------------" );
@@ -114,7 +114,7 @@ Define Class(
 				Char( Name Expr( this:failures[i][2] ) ),
 				Char( this:failures[i][2] )
 			) || " ";
-			Write( "\!n  Label: " || this:failures[i][1] || "\!n" );
+			Write( "\!n  Label: " || ut format test label(this:failures[i][1]) || "\!n" );
 			Write( "  Expected: " || char test expr || this:failures[i][3] || "\!n" );
 			Write( "  But: " || this:failures[i][4] || "\!n" );
 		);
@@ -124,7 +124,7 @@ Define Class(
 				Char( Name Expr( this:unexpected throws[i][2] ) ),
 				Char( this:unexpected throws[i][2] )
 			) || " ";
-			Write( "\!n  Label: " || this:unexpected throws[i][1] || "\!n" );
+			Write( "\!n  Label: " || ut format test label(this:unexpected throws[i][1]) || "\!n" );
 			Write( "  Expected: " || char test expr || this:unexpected throws[i][3] || "\!n" );
 			If( Is Empty( this:unexpected throws[i][4] ),
 				Write( "  But: " || "unexpectedly threw nothing\!n" ),
@@ -137,7 +137,7 @@ Define Class(
 				Char( Name Expr( this:skips[i][2] ) ),
 				Char( this:skips[i][2] )
 			) || " ";
-			Write( "\!n  Label: " || this:skips[i][1] || "\!n" );
+			Write( "\!n  Label: " || ut format test label(this:skips[i][1]) || "\!n" );
 			Write( "  Expected: " || char test expr || this:skips[i][3] || "\!n" );
 			Write( "  Skipped: " || this:skips[i][4] || "\!n");
 		);

--- a/Source/Reporters/FileAppendingReporter.jsl
+++ b/Source/Reporters/FileAppendingReporter.jsl
@@ -35,7 +35,7 @@ Define Class(
 		);
 		
 		failure = "";
-		failure ||= Eval Insert( "\!NFAILURE: ^Name Expr(test expr)^ ^shortDescription^ (^label^) " );
+		failure ||= Eval Insert( "\!NFAILURE: ^Name Expr(test expr)^ ^shortDescription^ (^ut format test label(label)^) " );
 		failure ||= Eval Insert( "\!N         Actual: ^mismatch^\!N       Expected: ^description^" );
 		
 		If( !IsEmpty( LRE ),
@@ -59,7 +59,7 @@ Define Class(
 		);
 
 		If(this:write successes,
-			success = Eval Insert( "\!NSUCCESS: ^Name Expr(test expr)^ ^shortDescription^ (^label^)" );
+			success = Eval Insert( "\!NSUCCESS: ^Name Expr(test expr)^ ^shortDescription^ (^ut format test label(label)^)" );
 			Save Text File( filepath, success, Mode( "Append" ) );
 		);
 		1;
@@ -73,12 +73,12 @@ Define Class(
 			);
 			If(Is Empty(Name Expr(test expr)) & Length(description) == 0,
 				msg = "";
-				msg ||= Eval Insert( "\!NSKIPPED: Entire test (^label^) " );
+				msg ||= Eval Insert( "\!NSKIPPED: Entire test (^ut format test label(label)^) " );
 				msg ||= Eval Insert( "\!N        Skipped: ^skip description^" );
 			,
 				short description = If( Length( description ) > 40, Left( description, 30 ) || " ...", description );
 				msg = "";
-				msg ||= Eval Insert( "\!NSKIPPED: ^Name Expr(test expr)^ ^short description^ (^label^) " );
+				msg ||= Eval Insert( "\!NSKIPPED: ^Name Expr(test expr)^ ^short description^ (^ut format test label(label)^) " );
 				msg ||= Eval Insert( "\!N        Skipped: ^skip description^\!N       Expected: ^description^" );
 			);
 			Save Text File( filepath, msg, Mode( "Append" ) );

--- a/Source/Reporters/JunitXMLReporter.jsl
+++ b/Source/Reporters/JunitXMLReporter.jsl
@@ -342,8 +342,10 @@ Define Class(
   //  and the test will be the given label or "Anonymous_Test_Name"
 
   parse_label = Method({label},
+    // TODO: Can be refactored to avoid list -> string -> list conversion
+    label = ut format test label(label);
     list_label = words(label, ::ut concat test label sep);
-
+	
     // set to anonymous test name if missing
     If(label == "",
       list_label = {"Anonymous_Test_Name"};

--- a/Source/Reporters/StreamingLogReporter.jsl
+++ b/Source/Reporters/StreamingLogReporter.jsl
@@ -25,7 +25,7 @@ Define Class("UtStreamingLogReporter",
 		n assertions++;
 		short description = If( Length( description ) > 40, Left( description, 30 ) || " ...", description );
 		failure = "";
-		failure ||= Eval Insert( "\!NFAILURE  Test #^n assertions^: ^Name Expr(test expr)^ ^short description^ (^label^) " );
+		failure ||= Eval Insert( "\!NFAILURE  Test #^n assertions^: ^Name Expr(test expr)^ ^short description^ (^ut format test label(label)^) " );
 		failure ||= Eval Insert( "\!N         Actual: ^mismatch^\!N       Expected: ^description^" );
 		If( !Is Empty( LRE ), failure ||= Eval Insert( "\!N            LRE: ^LRE^" ));
 		Write(failure);
@@ -41,13 +41,13 @@ Define Class("UtStreamingLogReporter",
 		If(this:write skips?,
 			If(Is Empty(Name Expr(test expr)) & Length(description) == 0,
 				msg = "";
-				msg ||= Eval Insert( "\!NSKIPPED  Test #^n assertions^: Entire test (^label^) " );
+				msg ||= Eval Insert( "\!NSKIPPED  Test #^n assertions^: Entire test (^ut format test label(label)^) " );
 				msg ||= Eval Insert( "\!N        Skipped: ^skip description^" );
 				Write(msg);
 			,
 				short description = If( Length( description ) > 40, Left( description, 30 ) || " ...", description );
 				msg = "";
-				msg ||= Eval Insert( "\!NSKIPPED  Test #^n assertions^: ^Name Expr(test expr)^ ^short description^ (^label^) " );
+				msg ||= Eval Insert( "\!NSKIPPED  Test #^n assertions^: ^Name Expr(test expr)^ ^short description^ (^ut format test label(label)^) " );
 				msg ||= Eval Insert( "\!N        Skipped: ^skip description^\!N       Expected: ^description^" );
 				Write(msg);
 			)

--- a/Tests/UnitTests/Reporters/CompositeReporter.jsl
+++ b/Tests/UnitTests/Reporters/CompositeReporter.jsl
@@ -11,31 +11,31 @@ CompositeReporterTests = ut test case("CompositeReporter")
 	));
 
 ut test(CompositeReporterTests, "Forwards Successes", Expr(
-	reporter1 << Expect Call( Expr( add success("label", "test expr", "description", "payload") ) );
-	reporter2 << Expect Call( Expr( add success("label", "test expr", "description", "payload") ) );
-	composite reporter << Add Success("label", "test expr", "description", "payload");
+	reporter1 << Expect Call( Expr( add success({"", "", "label", .}, "test expr", "description", "payload") ) );
+	reporter2 << Expect Call( Expr( add success({"", "", "label", .}, "test expr", "description", "payload") ) );
+	composite reporter << Add Success({"", "", "label", .}, "test expr", "description", "payload");
 ));
 
 ut test(CompositeReporterTests, "Forwards Failures", Expr(
-	reporter1 << Expect Call( Expr( add failure("label", "test expr", "description", "mismatch", "lre", "payload") ) );
-	reporter2 << Expect Call( Expr( add failure("label", "test expr", "description", "mismatch", "lre", "payload") ) );
-	composite reporter << Add Failure("label", "test expr", "description", "mismatch", "lre", "payload");
+	reporter1 << Expect Call( Expr( add failure({"", "", "label", .}, "test expr", "description", "mismatch", "lre", "payload") ) );
+	reporter2 << Expect Call( Expr( add failure({"", "", "label", .}, "test expr", "description", "mismatch", "lre", "payload") ) );
+	composite reporter << Add Failure({"", "", "label", .}, "test expr", "description", "mismatch", "lre", "payload");
 ));
 
 ut test(CompositeReporterTests, "Forwards Expression Failures", Expr(
-	reporter1 << Expect Call( Expr( add expression failure("label", "payload") ) );
-	reporter2 << Expect Call( Expr( add expression failure("label", "payload") ) );
-	composite reporter << Add Expression Failure("label", "payload");
+	reporter1 << Expect Call( Expr( add expression failure({"", "", "label", .}, "payload") ) );
+	reporter2 << Expect Call( Expr( add expression failure({"", "", "label", .}, "payload") ) );
+	composite reporter << Add Expression Failure({"", "", "label", .}, "payload");
 ));
 
 ut test(CompositeReporterTests, "Forwards Unexpected Throws", Expr(
-	reporter1 << Expect Call( Expr( add unexpected throw("label", "test expr", "description", "exception", "payload") ) );
-	reporter2 << Expect Call( Expr( add unexpected throw("label", "test expr", "description", "exception", "payload") ) );
-	composite reporter << Add Unexpected Throw("label", "test expr", "description", "exception", "payload");
+	reporter1 << Expect Call( Expr( add unexpected throw({"", "", "label", .}, "test expr", "description", "exception", "payload") ) );
+	reporter2 << Expect Call( Expr( add unexpected throw({"", "", "label", .}, "test expr", "description", "exception", "payload") ) );
+	composite reporter << Add Unexpected Throw({"", "", "label", .}, "test expr", "description", "exception", "payload");
 ));
 
 ut test(CompositeReporterTests, "Forwards Skips", Expr(
-	reporter1 << Expect Call( Expr( add skip("label", "test expr", "description", "skip description", "payload") ) );
-	reporter2 << Expect Call( Expr( add skip("label", "test expr", "description", "skip description", "payload") ) );
-	composite reporter << Add Skip("label", "test expr", "description", "skip description", "payload");
+	reporter1 << Expect Call( Expr( add skip({"", "", "label", .}, "test expr", "description", "skip description", "payload") ) );
+	reporter2 << Expect Call( Expr( add skip({"", "", "label", .}, "test expr", "description", "skip description", "payload") ) );
+	composite reporter << Add Skip({"", "", "label", .}, "test expr", "description", "skip description", "payload");
 ));

--- a/Tests/UnitTests/Reporters/FileAppendingReporterTest.jsl
+++ b/Tests/UnitTests/Reporters/FileAppendingReporterTest.jsl
@@ -15,17 +15,17 @@ ut test(FileAppendingReporterTests, "CreatesFile", Expr(
 ));
 
 ut test(FileAppendingReporterTests, "AddsFailuresToFile", Expr(
-  reporter << Add Failure("label", "test expr", "description", "mismatch", Empty());
+  reporter << Add Failure({"", "", "label", .}, "test expr", "description", "mismatch", Empty());
   ut assert value(File Size(reporter path), ut greater than(10));
 ));
 
 ut test(FileAppendingReporterTests, "SuccessesNotAddedByDefault", Expr(
-  reporter << Add Success("label", "test expr", "description", Empty());
+  reporter << Add Success({"", "", "label", .}, "test expr", "description", Empty());
   ut assert value(File Size(reporter path), ut less than(10));
 ));
 
 ut test(FileAppendingReporterTests, "AddsSuccessesToFile", Expr(
   reporter = ut file appending reporter(reporter path, write successes=1);
-  reporter << Add Success("label", "test expr", "description", Empty());
+  reporter << Add Success({"", "", "label", .}, "test expr", "description", Empty());
   ut assert value(File Size(reporter path), ut greater than(10));
 ));

--- a/Tests/UnitTests/SkipTest.jsl
+++ b/Tests/UnitTests/SkipTest.jsl
@@ -22,7 +22,7 @@ ut test(Skip If Tests, "Can be explicitly not skipped", Expr(
 
 ut test(Skip If Tests, "Can be explicitly skipped", Expr(
 	case << Skip If(1);
-	reporter << Expect Call(Expr(add skip("case ⮚ name ⮚ Skip", Empty(), "", "1", Empty())));
+	reporter << Expect Call(Expr(add skip({"case", "name", "Skip", .}, Empty(), "", "1", Empty())));
 	ut with reporter(reporter, Expr(
 		ut test(case, "name", Expr(
 			ut assert that(Expr(1 + 1), 3)
@@ -46,7 +46,7 @@ ut test(Skip If Tests, "Skip If applies to all tests", Expr(
 
 ut test(Skip If Tests, "Evaluates and uses expr for default skip description", Expr(
 	case << Skip If(Expr(1 > 0));
-	reporter << Expect Call(Expr(add skip("case ⮚ name ⮚ Skip", Empty(), "", "1 > 0", Empty())));
+	reporter << Expect Call(Expr(add skip({"case", "name", "Skip", .}, Empty(), "", "1 > 0", Empty())));
 	ut with reporter(reporter, Expr(
 		ut test(case, "name", Expr(
 			ut assert that(Expr(1 + 1), 3)
@@ -56,7 +56,7 @@ ut test(Skip If Tests, "Evaluates and uses expr for default skip description", E
 
 ut test(Skip If Tests, "Accepts custom skip description", Expr(
 	case << Skip If(1, "just because");
-	reporter << Expect Call(Expr(add skip("case ⮚ name ⮚ Skip", Empty(), "", "just because", Empty())));
+	reporter << Expect Call(Expr(add skip({"case", "name", "Skip", .}, Empty(), "", "just because", Empty())));
 	ut with reporter(reporter, Expr(
 		ut test(case, "name", Expr(
 			ut assert that(Expr(1 + 1), 3)
@@ -66,7 +66,7 @@ ut test(Skip If Tests, "Accepts custom skip description", Expr(
 
 ut test(Skip If Tests, "Custom skip description can be empty string", Expr(
 	case << Skip If(1, "");
-	reporter << Expect Call(Expr(add skip("case ⮚ name ⮚ Skip", Empty(), "", "", Empty())));
+	reporter << Expect Call(Expr(add skip({"case", "name", "Skip", .}, Empty(), "", "", Empty())));
 	ut with reporter(reporter, Expr(
 		ut test(case, "name", Expr(
 			ut assert that(Expr(1 + 1), 3)

--- a/Tests/UnitTests/TestCaseLogBenchmarkTest.jsl
+++ b/Tests/UnitTests/TestCaseLogBenchmarkTest.jsl
@@ -94,21 +94,11 @@ ut test(Log Benchmark, "Log Bench On Can Use a Matcher And Succeed", Expr(
 ));
 
 ut test(Log Benchmark, "Log Bench On Can Use a Matcher And Fail", Expr(
-	reporter << Expect Call(Expr(add failure(ut wild, ut wild, ut wild, ut wild, ut wild, ut wild)));
+	reporter << Expect Call(Expr(add failure({"case", "name", "Log Benchmark", .}, ut wild, ut wild, ut wild, ut wild, ut wild)));
 	rc = ut with reporter(reporter, Expr(
 		ut test("case", "name", Expr(Write("stuff")), ut log bench(1, ut ignoring whitespace("stu")));
 	));
 	ut assert that(Expr(rc), 0);
-));
-
-ut test(Log Benchmark, "Log Bench On Can Use a Matcher And Fail", Expr(
-	old label gen = Name Expr(ut test log benchmark label);
-	ut test log benchmark label = Function({c, n}, "my " || c || " " || n);
-	reporter << Expect Call(Expr(add failure("my case name", ut wild, ut wild, ut wild, ut wild, ut wild)));
-	rc = ut with reporter(reporter, Expr(
-		ut test("case", "name", Expr(Write("stuff")), ut log bench(1));
-	));
-	ut test log benchmark label = Name Expr(old label gen);
 ));
 
 ut test(Log Benchmark, "Nested tests can independently use log benchmarking #63", Expr(


### PR DESCRIPTION
Use a list of `{case name, test name, assertion label, assertion id}` rather than a string. Reporters no longer have to split on
`ut concat test label sep`. `ut concat test label` has been removed and replaced by a combination of `ut form test label`, `ut format test label`, and `ut fwd test label`.

With this change, `ut test` and `ut test case` are now first-class.

Closes #59

## Checklist

- [X] **I am adding new or changing current functionality.**
  - [X] I have added or updated the tests for the new or changed functionality in `Tests/UnitTests`.
  - [X] I have added note(s) to `CHANGELOG.md` as necessary.

## Contributing

- [X] I have read and agree to the [Contributor Agreement](https://github.com/sassoftware/jsl-hamcrest/blob/master/ContributorAgreement.txt)

Signed-off-by: Evan McCorkle <Evan.McCorkle@jmp.com>
