### PR TITLE
Log benchmark tests fail with customization.

### DIFF
--- a/Tests/UnitTests/TestCaseLogBenchmarkTest.jsl
+++ b/Tests/UnitTests/TestCaseLogBenchmarkTest.jsl
@@ -4,9 +4,16 @@
 Log Benchmark = ut test case("Log Benchmark")
 	<<Setup(Expr(
 		reporter = ut mock reporter();
+		
+		old label gen = Name Expr(ut test log benchmark label);
+		ut test log benchmark label = Function({case name, test name},
+			ut form test label( case name, test name, "Log Benchmark" )
+		);
 	))
 	<<Teardown(Expr(
 		reporter << Verify Expectations;
+		
+		ut test log benchmark label = Name Expr(old label gen);
 	));
 
 ut test(Log Benchmark, "Log Bench Default Does Not Capture Log", Expr(


### PR DESCRIPTION
When `ut test log benchmark label` is customized, the tests fail. Use default implementation for tests.

## Contributing

- [X] I have read and agree to the [Contributor Agreement](https://github.com/sassoftware/jsl-hamcrest/blob/master/ContributorAgreement.txt)

<!--- Replace your name and e-mail below -->
Signed-off-by: Evan McCorkle <Evan.McCorkle@jmp.com>
