### PR TITLE
Stop assert from clobbering exception_msg.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- `ut assert that` no longer clobbers `exception_msg` (started with skipped tests feature)
+
 ## [2.0.0]
 
 ### Added

--- a/Source/Core/Core.jsl
+++ b/Source/Core/Core.jsl
@@ -109,7 +109,7 @@ ut define documented function(
 					0;
 				);
 			,
-				Try(match info:skip, 0)
+				If(match info << Contains("skip"), match info:skip, 0)
 			,
 				ut global reporter:add skip( 
 					ut fwd test label( Name Expr( _utAssertThatNS:label ) ),

--- a/Tests/UnitTests/SkipTest.jsl
+++ b/Tests/UnitTests/SkipTest.jsl
@@ -138,3 +138,10 @@ ut test(Skip Tests, "Default skip description can be empty string", Expr(
 	mi = ut skip(3, "") << matches(Expr( 1 + 1 ));
 	ut assert that(Expr(mi:skip description), "");
 ));
+
+// Bug introduced by ut skip handling
+ut test("Assert That", "Doesn't clobber exception_msg", Expr(
+	Try(Sin("a"));
+	ut assert that( Expr( 1 + 1 ), 2 ); // clobbers by Try(match info:skip, 0)
+	ut assert that( Expr( exception_msg[1] ), "Cannot convert argument to a number [or matrix]" );
+));


### PR DESCRIPTION
This solves an issue introduced by the `ut skip` handling in `ut assert that`. Because of that implementation, `ut assert that` could overwrite `exception_msg`. Since you may be trying to test the contents of `exception_msg`, we want to avoid that. I changed to implementation prevent this.

Note that in most cases, you can probably just use `ut throws` rather than explicitly testing `exception_msg`. For other cases, hopefully we can add something for #124 to help there.

## Checklist

- [X] **I am adding new or changing current functionality.**
  - [X] I have added or updated the tests for the new or changed functionality in `Tests/UnitTests`.
  - [X] I have added note(s) to `CHANGELOG.md` as necessary.

## Contributing

- [X] I have read and agree to the [Contributor Agreement](https://github.com/sassoftware/jsl-hamcrest/blob/master/ContributorAgreement.txt)

<!--- Replace your name and e-mail below -->
Signed-off-by: Evan McCorkle <Evan.McCorkle@jmp.com>
