### PR TITLE
Fixes mock examples.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- `ut expect call` and `ut verify mock` examples now run correctly.
 - `ut assert that` no longer clobbers `exception_msg` (started with skipped tests feature)
 
 ## [2.0.0]

--- a/Source/Core/Mock.jsl
+++ b/Source/Core/Mock.jsl
@@ -186,7 +186,7 @@ ut define documented function(
 	Name Expr(ut expect call),
 	"ut expect call( mock, {arg1 matcher, arg2 matcher, ...} )",
 	"Defines expectations for a mock function. Must be called before the actual call to the mock.",
-	{{"Simple", mock = ut mock function(Function({x}, .)); ut expect call(mock, {ut greater than(6)}); mock:fn(5)}}
+	{{"Simple", mock = ut mock function({x}, Expr(.)); ut expect call(mock, {ut greater than(6)}); mock:fn(5)}}
 );
 
 
@@ -216,5 +216,5 @@ ut define documented function(
 	Name Expr(ut verify mock),
 	"ut verify mock( mock )",
 	"Tests that a mock function has been called the expected number of times. Should be called after other testing is complete.",
-	{{"Simple", mock = ut mock function({}, Expr(.)); mock:fn(5); ut verify mock(mock)}}
+	{{"Simple", mock = ut mock function({x}, Expr(.)); mock:fn(5); ut verify mock(mock)}}
 );


### PR DESCRIPTION
The `ut expect call` and `ut verify mock` examples were broken. The former was using old syntax and the latter was just incorrect.

## Contributing

- [X] I have read and agree to the [Contributor Agreement](https://github.com/sassoftware/jsl-hamcrest/blob/master/ContributorAgreement.txt)

<!--- Replace your name and e-mail below -->
Signed-off-by: Evan R. McCorkle <Evan.McCorkle@jmp.com>
