### PR TITLE
Issue specific failure for non-scalar comparisons.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 - Use a more uniform `Method` call style of `this:inner << describe` rather than `this:inner:describe` to prevent a memory leak.
 - `ut expect call` and `ut verify mock` examples now run correctly.
 - `ut assert that` no longer clobbers `exception_msg` (started with skipped tests feature)
+- Comparison matchers like `ut less than or equal to` now issue a specific failure for non-scalar comparisons (#135)
 
 ## [2.0.0]
 

--- a/Source/Matchers/OrderingComparison.jsl
+++ b/Source/Matchers/OrderingComparison.jsl
@@ -26,13 +26,17 @@ Define Class(
 	matches = Method( {test expr},
 		actual = Eval( test expr );
 		success = this:comparison function( actual, this:value );
-		If( 
+		IfMz( 
 			Is Missing( success ),
 				mismatch = "was " || Char( actual );
 				::ut match info failure( mismatch );
 		,
 			success == 1,
 				::ut match info success();
+		,
+			Is Matrix( success ),
+				mismatch = "was non-scalar " || Char( actual );
+				::ut match info failure( mismatch );
 		,
 				mismatch = "was " || Char( actual );
 				::ut match info failure( mismatch );

--- a/Tests/UnitTests/Matchers/EqualToTest.jsl
+++ b/Tests/UnitTests/Matchers/EqualToTest.jsl
@@ -1,4 +1,4 @@
-// Copyright © 2019, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
+﻿// Copyright © 2019, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Base EqualToMatcher using strings
@@ -46,6 +46,12 @@ ut test( "EqualToMatcher", "Handles Strings With Children (#88)", Expr(
 	ut assert value("abc"(1, 2, 3), ut equal to("abc"(1, 2, 3)));
 	ut assert value("abc"(1, 2, 3), ut not(ut equal to(Expr("ab"(1, 2, 3)))));
 	ut assert value("abc"(1, 2, 3), ut not(ut equal to(Expr("abc"(4, 5)))));
+));
+
+ut test( "LessThanOrEqualToMatcher", "Fails with Matrix (#135)", Expr(
+	matcher = ut less than or equal to(3);
+	match info = matcher << Matches( 1::3 );
+	ut assert value(match info << get mismatch, ut equal to("was non-scalar [1 2 3]"));
 ));
 
 // TODO: Other EqualToMatcher subclasses


### PR DESCRIPTION
Fixes #135.

Changes `ut less than or equal to` and other comparison matchers to issue a specific failure for non-scalar comparisons.

- [x] **I am adding new or changing current functionality.**
  - [x] I have added or updated the tests for the new or changed functionality in `Tests/UnitTests`.
  - [x] I have added note(s) to `CHANGELOG.md` as necessary.

## Contributing

- [x] I have read and agree to the [Contributor Agreement](https://github.com/sassoftware/jsl-hamcrest/blob/master/ContributorAgreement.txt)

<!--- Replace your name and e-mail below -->
Signed-off-by: Evan McCorkle <Evan.McCorkle@jmp.com>
